### PR TITLE
Deprecate using recipe files directly in `zocalo.go`

### DIFF
--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -57,7 +57,7 @@ def run():
         action="store",
         type="string",
         default="",
-        help="Run recipe contained in this file.",
+        help=SUPPRESS_HELP,
     )
     parser.add_option(
         "-n",
@@ -198,6 +198,10 @@ def run():
         sys.exit("No recipes specified.")
 
     if options.recipefile:
+        print(
+            "Using recipe files in zocalo.go is deprecated, and "
+            "the option to do this will be removed in the future"
+        )
         with open(options.recipefile) as fh:
             custom_recipe = workflows.recipe.Recipe(json.load(fh))
         custom_recipe.validate()

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -24,9 +24,8 @@ import zocalo.configuration
 def run():
     parser = OptionParser(
         usage="zocalo.go [options] dcid",
-        description="Triggers processing of a standard "
-        "recipe, of an arbitrary recipe from a local file, or of an entry in "
-        "the ISPyB processing table.",
+        description="Triggers processing of a recipe, or of an"
+        " entry in the ISPyB processing table.",
     )
 
     parser.add_option("-?", action="help", help=SUPPRESS_HELP)
@@ -37,7 +36,9 @@ def run():
         metavar="RCP",
         action="append",
         default=[],
-        help="Name of a recipe to run. Can be used multiple times. Recipe names correspond to filenames (excluding .json) in /dls_sw/apps/zocalo/live/recipes",
+        help="Name of a recipe to run. Can be used multiple times. "
+        "Recipe names correspond to filenames (excluding .json) in "
+        "/dls_sw/apps/zocalo/live/recipes",
     )
     parser.add_option(
         "-a",


### PR DESCRIPTION
Hide the command line option and tell people to stop using it, in preparation for removing it (#92)