### PR TITLE
try to make env activation consistent and reusable

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.9.0 (2021-08-..)
+------------------
+* Removed --live/--test command line arguments, use -e/--environment instead
+
 0.8.1 (2021-07-08)
 ------------------
 * Keep wrapper status threads alive through transport disconnection events

--- a/contrib/site-configuration.yml
+++ b/contrib/site-configuration.yml
@@ -87,11 +87,7 @@ environments:
   test:
     transport: stomp-test
 
-# Define the default environment for the two distinct invocations of
-# zocalo, as a service, or via the cli:
-defaults:
-  service: test
-  cli: live
+  default: live
 
 # The configuration is modular. You can merge additional configuration files
 # into this file by listing them under the 'include' key.

--- a/contrib/site-configuration.yml
+++ b/contrib/site-configuration.yml
@@ -70,10 +70,9 @@ unknown:
 # Deviating from the 12factor model, the configuration file groups
 # configurations together into environments. You can declare as many
 # environments as you like, the names may translate into command line
-# parameters, eg. "zocalo.service --live" will start from the 'live'
-# configuration, and "zocalo.service --test" from the 'test' configuration.
-# Be mindful that names you declare here may therefore collide with command
-# line parameters declared elsewhere.
+# parameters, eg. "zocalo.service --env=live" will start from the 'live'
+# configuration, and "zocalo.service --env=test" from the 'test' configuration.
+# (The exact argument layout may depend on the command.)
 # The only special configuration name is 'default', which will be the
 # environment that is loaded if no other environment is specified.
 environments:

--- a/contrib/site-configuration.yml
+++ b/contrib/site-configuration.yml
@@ -87,6 +87,12 @@ environments:
   test:
     transport: stomp-test
 
+# Define the default environment for the two distinct invocations of
+# zocalo, as a service, or via the cli:
+defaults:
+  service: test
+  cli: live
+
 # The configuration is modular. You can merge additional configuration files
 # into this file by listing them under the 'include' key.
 # Every file is loaded individually and unconditionally. All files must be

--- a/contrib/site-configuration.yml
+++ b/contrib/site-configuration.yml
@@ -3,6 +3,8 @@
 # This is a YAML formatted configuration file, see for example
 # https://getopentest.org/reference/yaml-primer.html if you are not familiar
 # with YAML.
+# You can find the full site configuration file documentation at
+# https://zocalo.readthedocs.io/en/latest/siteconfig.html#configuration-file-format
 
 # The intention of this file is to contain all site-specific configuration in a
 # sufficiently flexible format so that we can remove all configuration from the
@@ -72,6 +74,8 @@ unknown:
 # configuration, and "zocalo.service --test" from the 'test' configuration.
 # Be mindful that names you declare here may therefore collide with command
 # line parameters declared elsewhere.
+# The only special configuration name is 'default', which will be the
+# environment that is loaded if no other environment is specified.
 environments:
   live:
     # Each environment definition can contain named elements as well as a
@@ -84,10 +88,13 @@ environments:
     transport: stomp-live
     plugins:
       - graylog-live
+
   test:
     transport: stomp-test
 
   default: live
+    # Environment definitions can also consist of a simple string only. In this
+    # case they are purely an alias for another environment definition.
 
 # The configuration is modular. You can merge additional configuration files
 # into this file by listing them under the 'include' key.

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -118,6 +118,31 @@ Groups are loaded alphabetically, with one exception: ``plugins`` is special
 and is always loaded last. Within each group the plugin configurations are
 loaded in the specified order.
 
+A special environment name is ``default``, which is the environment that will
+be loaded if no other environment is loaded. You can use aliasing (see below
+under :ref:`environment_aliases`) to point ``default`` to a different, more
+self-explanatory environment name.
+
+.. _environment_aliases:
+
+Environment aliases
+^^^^^^^^^^^^^^^^^^^
+
+You can create aliases for environment names by just giving the name of the
+underlying environment name. You can only do pure aliasing here, you can not
+override parts of the referenced environment at this time.
+
+This configuration gives you an ``alias`` environment, that is exactly
+identical to the environment named ``real``:
+
+.. code-block:: yaml
+
+  environments:
+    real:
+      plugins:
+        - ...
+    alias: real
+
 
 References to further files
 ---------------------------

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -143,6 +143,9 @@ identical to the environment named ``real``:
         - ...
     alias: real
 
+Aliases are resolved immediately when they are encountered. The aliased
+environment therefore has to be specified in the same configuration file.
+
 
 References to further files
 ---------------------------

--- a/src/zocalo/__init__.py
+++ b/src/zocalo/__init__.py
@@ -4,7 +4,6 @@ import logging
 import socket
 import warnings
 
-import graypy
 import graypy.handler
 
 __author__ = "Markus Gerstel"

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -24,8 +24,7 @@ import zocalo.configuration.argparse
 
 def run():
     zc = zocalo.configuration.from_file()
-    envs = zocalo.configuration.argparse.get_specified_environments()
-    zc.activate_environments(envs)
+    zc.activate()
 
     parser = OptionParser(
         usage="zocalo.go [options] dcid",

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -3,6 +3,7 @@
 #   Process a datacollection
 #
 
+import argparse
 import getpass
 import json
 import pathlib
@@ -17,6 +18,7 @@ import workflows.recipe
 from workflows.transport.stomp_transport import StompTransport
 
 import zocalo.configuration
+import zocalo.configuration.argparse
 
 # Example: zocalo.go -r example-xia2 527189
 
@@ -112,15 +114,10 @@ def run():
         action="store_true",
         dest="test",
         default=False,
-        help="Run in ActiveMQ testing (zocdev) namespace",
+        help=argparse.SUPPRESS,
     )
-    zc = zocalo.configuration.from_file()
-    if "--test" in sys.argv:
-        if "test" in zc.environments:
-            zc.activate_environment("test")
-    else:
-        if "live" in zc.environments:
-            zc.activate_environment("live")
+    zc, _ = zocalo.configuration.activate_from_file()
+    zocalo.configuration.argparse.add_env_option(zc, parser)
 
     StompTransport.add_command_line_options(parser)
     (options, args) = parser.parse_args(sys.argv[1:])
@@ -196,6 +193,9 @@ def run():
         and not options.reprocess
     ):
         sys.exit("No recipes specified.")
+
+    if options.test:
+        print("--test is deprecated. Use -e=test")
 
     if options.recipefile:
         with open(options.recipefile) as fh:

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -23,6 +23,10 @@ import zocalo.configuration.argparse
 
 
 def run():
+    zc = zocalo.configuration.from_file()
+    envs = zocalo.configuration.argparse.get_specified_environments()
+    zc.activate_environments(envs)
+
     parser = OptionParser(
         usage="zocalo.go [options] dcid",
         description="Triggers processing of a standard "
@@ -107,16 +111,18 @@ def run():
         default=False,
         help="Verify that everything is in place that the message could be sent, but don't actually send the message",
     )
-
     parser.add_option(
-        "--test",
-        action="store_true",
-        dest="test",
-        default=False,
-        help=SUPPRESS_HELP,
+        "-e",
+        "--environment",
+        dest="environment",
+        metavar="ENV",
+        action="append",
+        default=[],
+        type="choice",
+        choices=sorted(zc.environments),
+        help="Enable site-specific settings. Choices are: "
+        + ", ".join(sorted(zc.environments)),
     )
-    zc, _ = zocalo.configuration.activate_from_file()
-    zocalo.configuration.argparse.add_env_option(zc, parser)
 
     StompTransport.add_command_line_options(parser)
     (options, args) = parser.parse_args(sys.argv[1:])
@@ -192,9 +198,6 @@ def run():
         and not options.reprocess
     ):
         sys.exit("No recipes specified.")
-
-    if options.test:
-        print("--test is deprecated. Use -e=test")
 
     if options.recipefile:
         with open(options.recipefile) as fh:

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -3,7 +3,6 @@
 #   Process a datacollection
 #
 
-import argparse
 import getpass
 import json
 import pathlib
@@ -114,7 +113,7 @@ def run():
         action="store_true",
         dest="test",
         default=False,
-        help=argparse.SUPPRESS,
+        help=SUPPRESS_HELP,
     )
     zc, _ = zocalo.configuration.activate_from_file()
     zocalo.configuration.argparse.add_env_option(zc, parser)

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -12,11 +12,9 @@ import uuid
 from optparse import SUPPRESS_HELP, OptionParser
 from pprint import pprint
 
-import workflows
 import workflows.recipe
 from workflows.transport.stomp_transport import StompTransport
 
-import zocalo.configuration
 import zocalo.configuration.argparse
 
 # Example: zocalo.go -r example-xia2 527189

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -41,7 +41,8 @@ def run():
         metavar="RCP",
         action="append",
         default=[],
-        help="Name of a recipe to run. Can be used multiple times. Recipe names correspond to filenames (excluding .json) in /dls_sw/apps/zocalo/live/recipes",
+        help="Name of a recipe to run. Can be used multiple times. "
+        "Recipe names correspond to filenames (excluding .json) in /dls_sw/apps/zocalo/live/recipes",
     )
     parser.add_option(
         "-a",
@@ -110,19 +111,7 @@ def run():
         default=False,
         help="Verify that everything is in place that the message could be sent, but don't actually send the message",
     )
-    parser.add_option(
-        "-e",
-        "--environment",
-        dest="environment",
-        metavar="ENV",
-        action="append",
-        default=[],
-        type="choice",
-        choices=sorted(zc.environments),
-        help="Enable site-specific settings. Choices are: "
-        + ", ".join(sorted(zc.environments)),
-    )
-
+    zc.add_command_line_options(parser)
     StompTransport.add_command_line_options(parser)
     (options, args) = parser.parse_args(sys.argv[1:])
 

--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -11,13 +11,11 @@ import sys
 from optparse import SUPPRESS_HELP, OptionParser
 
 import pkg_resources
-import workflows
 import workflows.recipe.wrapper
 import workflows.services.common_service
 import workflows.transport
 import workflows.util
 
-import zocalo.configuration
 import zocalo.configuration.argparse
 import zocalo.wrapper
 

--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -61,7 +61,7 @@ def run():
         dest="recipewrapper",
         metavar="RW",
         default=None,
-        help="A serialized recipe wrapper file " "for downstream communication",
+        help="A serialized recipe wrapper file for downstream communication",
     )
 
     parser.add_option(

--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -34,8 +34,7 @@ def run():
     log = logging.getLogger("zocalo.wrap")
 
     zc = zocalo.configuration.from_file()
-    envs = zocalo.configuration.argparse.get_specified_environments()
-    zc.activate_environments(envs)
+    zc.activate()
 
     known_wrappers = {
         e.name: e.load for e in pkg_resources.iter_entry_points("zocalo.wrappers")

--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -81,19 +81,8 @@ def run():
         default=False,
         help="Show debug level messages",
     )
-    parser.add_option(
-        "-e",
-        "--environment",
-        dest="environment",
-        metavar="ENV",
-        action="append",
-        default=[],
-        type="choice",
-        choices=sorted(zc.environments),
-        help="Enable site-specific settings. Choices are: "
-        + ", ".join(sorted(zc.environments)),
-    )
 
+    zc.add_command_line_options(parser)
     workflows.transport.add_command_line_options(parser)
 
     # Parse command line arguments

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -26,7 +26,7 @@ class DefaultConfigSchema(mm.Schema):
 
 class ConfigSchema(mm.Schema):
     version = mm.fields.Int(required=True)
-    defaults = mm.fields.Nested(DefaultConfigSchema, required=True)
+    defaults = mm.fields.Nested(DefaultConfigSchema)
     environments = mm.fields.Dict(
         keys=mm.fields.Str(),
         values=mm.fields.Dict(

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -360,5 +360,7 @@ def activate_from_file(default_env="live") -> Configuration:
     for env in envs:
         if env in zc.environments:
             zc.activate_environment(env)
+        else:
+            logger.warning(f"Trying to activate {env} which is not a valid environment")
 
     return zc, envs

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -6,6 +6,7 @@ import logging
 import operator
 import os
 import pathlib
+import sys
 import typing
 
 import marshmallow as mm
@@ -13,6 +14,7 @@ import pkg_resources
 import yaml
 
 from zocalo import ConfigurationError
+import zocalo.configuration.argparse
 
 logger = logging.getLogger("zocalo.configuration")
 
@@ -328,3 +330,23 @@ def from_file(config_file=None) -> Configuration:
 
 def from_string(configuration: str) -> Configuration:
     return Configuration(_merge_configuration(configuration, None, pathlib.Path.cwd()))
+
+
+def activate_from_file(default="live") -> Configuration:
+    zc = from_file()
+    envs = zocalo.configuration.argparse.get_specified_environments()
+
+    if "--live" in sys.argv:  # deprecated
+        envs = ["live"]
+    if "--test" in sys.argv:
+        envs = ["test"]
+
+    for env in envs:
+        if env in zc.environments:
+            zc.activate_environment(env)
+
+    if not envs and default is not None:
+        envs = [default]
+        zc.activate_environment(default)
+
+    return zc, envs

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -216,7 +216,6 @@ def _read_configuration_yaml(configuration: str) -> dict:
     # Convert environment shorthands: environment lists to dictionaries
     # and individual plugin configurations to single element lists
     for environment in yaml_dict.setdefault("environments", {}):
-        # Convert shorthand stringsenvironment shorthand lists to dictionaries
         if (
             isinstance(yaml_dict["environments"][environment], str)
             and environment == "default"

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -97,7 +97,7 @@ class Configuration:
     def active_environments(self) -> typing.Tuple[str]:
         return tuple(self._activated)
 
-    def _resolve(self, plugin_configuration: str) -> bool:
+    def _resolve(self, plugin_configuration: str):
         try:
             configuration = self._plugin_configurations[
                 plugin_configuration

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -91,13 +91,10 @@ class Configuration:
 
     def __init__(self, yaml_dict: dict):
         self._activated: typing.List[str] = []
-        self._environments: typing.Dict[str, typing.List[str]] = yaml_dict.get(
-            "environments", {}
-        )
-        try:
-            self._default = self._environments.pop("default")
-        except KeyError:
-            self._default = None
+        self._environments: typing.Dict[str, typing.List[str]] = {
+            k: v for k, v in yaml_dict.get("environments", {}).items() if k != "default"
+        }
+        self._default = yaml_dict.get("environments", {}).get("default")
         self._plugin_configurations: typing.Dict[
             str, typing.Union[pathlib.Path, typing.Dict[str, typing.Any]]
         ] = {

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -13,8 +13,8 @@ import marshmallow as mm
 import pkg_resources
 import yaml
 
-from zocalo import ConfigurationError
 import zocalo.configuration.argparse
+from zocalo import ConfigurationError
 
 logger = logging.getLogger("zocalo.configuration")
 

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -164,10 +164,10 @@ class Configuration:
         """
         if envs is None:
             envs = zocalo.configuration.argparse.get_specified_environments(**kwargs)
-        if not envs and "default" in self._environments:
+        if default and not envs and "default" in self._environments:
             envs = ["default"]
         for environment in envs:
-            self.activate(environment)
+            self.activate_environment(environment)
 
         return tuple(envs)
 

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -76,10 +76,9 @@ class Configuration:
 
     def __init__(self, yaml_dict: dict):
         self._activated: typing.List[str] = []
-        self._environments: typing.Dict[str, typing.List[str]] = {
-            k: v for k, v in yaml_dict.get("environments", {}).items() if k != "default"
-        }
-        self._default = yaml_dict.get("environments", {}).get("default")
+        self._environments: typing.Dict[str, typing.List[str]] = yaml_dict.get(
+            "environments", {}
+        )
         self._plugin_configurations: typing.Dict[
             str, typing.Union[pathlib.Path, typing.Dict[str, typing.Any]]
         ] = {
@@ -89,10 +88,6 @@ class Configuration:
         }
         for name in _configuration_plugins:
             setattr(self, "_" + name, None)
-
-    @property
-    def default(self) -> str:
-        return self._default
 
     @property
     def environments(self) -> typing.Set[str]:
@@ -169,11 +164,7 @@ class Configuration:
             activated = f", environment '{self._activated[0]}' activated"
         else:
             activated = f", environments {self._activated} activated"
-        if self.default:
-            default = f" (default '{self.default}')"
-        else:
-            default = ""
-        return f"<ZocaloConfiguration containing {environments} environments{default}, {plugin_configurations} plugin configurations{unresolved}{activated}>"
+        return f"<ZocaloConfiguration containing {environments} environments, {plugin_configurations} plugin configurations{unresolved}{activated}>"
 
     __repr__ = __str__
 
@@ -329,9 +320,6 @@ def _merge_configuration(
 
     # Flatten the data structure for each environment to a deduplicated ordered list of plugins
     for environment in parsed["environments"]:
-        if environment == "default":
-            continue
-
         # First, order groups alphabetically - except 'plugins', which always comes last
         ordered_plugins = [
             parsed["environments"][environment][group]

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -345,7 +345,7 @@ def activate_from_file(default="live") -> Configuration:
         if env in zc.environments:
             zc.activate_environment(env)
 
-    if not envs and default is not None:
+    if not envs:
         envs = [default]
         zc.activate_environment(default)
 

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -13,7 +13,6 @@ import marshmallow as mm
 import pkg_resources
 import yaml
 
-import zocalo.configuration.argparse
 from zocalo import ConfigurationError
 
 logger = logging.getLogger("zocalo.configuration")
@@ -358,25 +357,3 @@ def from_file(config_file=None) -> Configuration:
 
 def from_string(configuration: str) -> Configuration:
     return Configuration(_merge_configuration(configuration, None, pathlib.Path.cwd()))
-
-
-def activate_from_file() -> Configuration:
-    zc = from_file()
-    envs = zocalo.configuration.argparse.get_specified_environments()
-
-    if "--live" in sys.argv:  # deprecated
-        envs = ["live"]
-    if "--test" in sys.argv:
-        envs = ["test"]
-
-    if not envs and zc.default:
-        envs = [zc.default]
-
-    for env in envs:
-        if env in zc.environments:
-            logger.debug(f"Activating environment '{env}'")
-            zc.activate_environment(env)
-        else:
-            logger.warning(f"Trying to activate {env} which is not a valid environment")
-
-    return zc, envs

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -52,7 +52,7 @@ class PluginSchema(mm.Schema):
     )
 
 
-_reserved_names = {"activated", "environments", "plugin_configurations", "default"}
+_reserved_names = {"activated", "environments", "plugin_configurations"}
 
 
 def _check_valid_plugin_name(name: str) -> bool:

--- a/src/zocalo/configuration/argparse.py
+++ b/src/zocalo/configuration/argparse.py
@@ -41,7 +41,7 @@ def add_env_option(zc, parser):
             dest="environment",
             metavar="ENV",
             action="append",
-            default=zc.default,
+            default=[zc.default],
             choices=sorted(zc.environments),
             help="Enable site-specific settings. Choices are: "
             + ", ".join(sorted(zc.environments))
@@ -54,7 +54,7 @@ def add_env_option(zc, parser):
             dest="environment",
             metavar="ENV",
             action="append",
-            default=zc.default,
+            default=[zc.default],
             type="choice",
             choices=sorted(zc.environments),
             help="Enable site-specific settings. Choices are: "

--- a/src/zocalo/configuration/argparse.py
+++ b/src/zocalo/configuration/argparse.py
@@ -33,7 +33,7 @@ def get_specified_environments(
     return selected_environments[0].envs
 
 
-def add_env_option(zc, parser, default="live"):
+def add_env_option(zc, parser):
     if isinstance(parser, argparse.ArgumentParser):
         parser.add_argument(
             "-e",
@@ -41,7 +41,7 @@ def add_env_option(zc, parser, default="live"):
             dest="environment",
             metavar="ENV",
             action="append",
-            default=default,
+            default=zc.default,
             choices=sorted(zc.environments),
             help="Enable site-specific settings. Choices are: "
             + ", ".join(sorted(zc.environments))
@@ -54,7 +54,7 @@ def add_env_option(zc, parser, default="live"):
             dest="environment",
             metavar="ENV",
             action="append",
-            default=default,
+            default=zc.default,
             type="choice",
             choices=sorted(zc.environments),
             help="Enable site-specific settings. Choices are: "

--- a/src/zocalo/configuration/argparse.py
+++ b/src/zocalo/configuration/argparse.py
@@ -24,7 +24,10 @@ def get_specified_environments(
 
     env_parser = _EnvParser()
     env_parser.add_argument(
-        *arguments, dest="envs", action="append", default=[],
+        *arguments,
+        dest="envs",
+        action="append",
+        default=[],
     )
     selected_environments = env_parser.parse_known_args()
     if not selected_environments:

--- a/src/zocalo/configuration/argparse.py
+++ b/src/zocalo/configuration/argparse.py
@@ -24,13 +24,40 @@ def get_specified_environments(
 
     env_parser = _EnvParser()
     env_parser.add_argument(
-        *arguments,
-        dest="envs",
-        action="append",
-        default=[],
+        *arguments, dest="envs", action="append", default=[],
     )
     selected_environments = env_parser.parse_known_args()
     if not selected_environments:
         return []
 
     return selected_environments[0].envs
+
+
+def add_env_option(zc, parser, default="live"):
+    if isinstance(parser, argparse.ArgumentParser):
+        parser.add_argument(
+            "-e",
+            "--environment",
+            dest="environment",
+            metavar="ENV",
+            action="append",
+            default=default,
+            choices=sorted(zc.environments),
+            help="Enable site-specific settings. Choices are: "
+            + ", ".join(sorted(zc.environments))
+            + " (default: %(default)s)",
+        )
+    else:
+        parser.add_option(
+            "-e",
+            "--environment",
+            dest="environment",
+            metavar="ENV",
+            action="append",
+            default=default,
+            type="choice",
+            choices=sorted(zc.environments),
+            help="Enable site-specific settings. Choices are: "
+            + ", ".join(sorted(zc.environments))
+            + " (default: %default)",
+        )

--- a/src/zocalo/configuration/argparse.py
+++ b/src/zocalo/configuration/argparse.py
@@ -19,8 +19,8 @@ def get_specified_environments(
     """Extract a list of all environments putatively specified on the command line.
     Returns an empty list if there are any parsing issues or there are no specified
     environments. This function is designed to be used as the first of two passes
-    for parsing command line options, so that the environments can be taken account
-    when parsing all other commands."""
+    for parsing command line options, so that the environments can be taken into
+    account when parsing all other commands."""
 
     env_parser = _EnvParser()
     env_parser.add_argument(
@@ -34,33 +34,3 @@ def get_specified_environments(
         return []
 
     return selected_environments[0].envs
-
-
-def add_env_option(zc, parser):
-    if isinstance(parser, argparse.ArgumentParser):
-        parser.add_argument(
-            "-e",
-            "--environment",
-            dest="environment",
-            metavar="ENV",
-            action="append",
-            default=[zc.default],
-            choices=sorted(zc.environments),
-            help="Enable site-specific settings. Choices are: "
-            + ", ".join(sorted(zc.environments))
-            + " (default: %(default)s)",
-        )
-    else:
-        parser.add_option(
-            "-e",
-            "--environment",
-            dest="environment",
-            metavar="ENV",
-            action="append",
-            default=[zc.default],
-            type="choice",
-            choices=sorted(zc.environments),
-            help="Enable site-specific settings. Choices are: "
-            + ", ".join(sorted(zc.environments))
-            + " (default: %default)",
-        )

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -53,19 +53,8 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
 
     def __init__(self):
         # load configuration and initialize logging
-        self._zc = zocalo.configuration.from_file()
-        envs = zocalo.configuration.argparse.get_specified_environments()
-
-        if not envs:  # deprecated
-            if "--live" in sys.argv:
-                envs = ["live"]
-            else:
-                envs = ["test"]
+        self._zc, envs = zocalo.configuration.activate_from_file(default="test")
         self.use_live_infrastructure = "live" in envs  # deprecated
-
-        for env in envs:
-            if env in self._zc.environments:
-                self._zc.activate_environment(env)
         self.setup_logging()
 
         if not hasattr(self._zc, "graylog") or not self._zc.graylog:
@@ -118,18 +107,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
             default=False,
             help=optparse.SUPPRESS_HELP,
         )
-        parser.add_option(
-            "-e",
-            "--environment",
-            dest="environment",
-            metavar="ENV",
-            action="append",
-            default=[],
-            type="choice",
-            choices=sorted(self._zc.environments),
-            help="Enable site-specific settings. Choices are: "
-            + ", ".join(sorted(self._zc.environments)),
-        )
+        zocalo.configuration.argparse.add_env_option(self._zc, parser, default="test")
         self.log.debug("Launching " + str(sys.argv))
 
     def on_parsing(self, options, args):

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -53,7 +53,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
 
     def __init__(self):
         # load configuration and initialize logging
-        self._zc, envs = zocalo.configuration.activate_from_file(caller="service")
+        self._zc, envs = zocalo.configuration.activate_from_file()
         self.use_live_infrastructure = "live" in envs  # deprecated
         self.setup_logging()
 

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -1,11 +1,4 @@
-# zocalo.service defaults to running in the testing ActiveMQ namespace (zocdev),
-# rather than the live namespace (zocalo).
-# This is to stop servers started by developers on their machines accidentally
-# interfering with live data processing.
-# To run a live server you must specify '--live'
-
 import logging
-import optparse
 import os
 import sys
 
@@ -54,12 +47,10 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
     def __init__(self):
         # load configuration and initialize logging
         self._zc = zocalo.configuration.from_file()
-        envs = zocalo.configuration.argparse.get_specified_environments()
-        self.use_live_infrastructure = "live" in envs  # deprecated
-
-        for env in envs:
-            if env in self._zc.environments:
-                self._zc.activate_environment(env)
+        envs = self._zc.activate()
+        self.use_live_infrastructure = ("live" in envs) or (
+            "default" in envs
+        )  # deprecated
         self.setup_logging()
 
         if not hasattr(self._zc, "graylog") or not self._zc.graylog:

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -53,7 +53,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
 
     def __init__(self):
         # load configuration and initialize logging
-        self._zc, envs = zocalo.configuration.activate_from_file(default_env="test")
+        self._zc, envs = zocalo.configuration.activate_from_file(caller="service")
         self.use_live_infrastructure = "live" in envs  # deprecated
         self.setup_logging()
 

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -2,7 +2,6 @@ import logging
 import os
 import sys
 
-import workflows
 import workflows.contrib.start_service
 
 import zocalo.configuration.argparse

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -89,18 +89,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
             default=False,
             help="Restart service on failure",
         )
-        parser.add_option(
-            "-e",
-            "--environment",
-            dest="environment",
-            metavar="ENV",
-            action="append",
-            default=[],
-            type="choice",
-            choices=sorted(self._zc.environments),
-            help="Enable site-specific settings. Choices are: "
-            + ", ".join(sorted(self._zc.environments)),
-        )
+        self._zc.add_command_line_options(parser)
         self.log.debug("Launching %r", sys.argv)
 
     def on_parsing(self, options, args):

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -53,7 +53,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
 
     def __init__(self):
         # load configuration and initialize logging
-        self._zc, envs = zocalo.configuration.activate_from_file(default="test")
+        self._zc, envs = zocalo.configuration.activate_from_file(default_env="test")
         self.use_live_infrastructure = "live" in envs  # deprecated
         self.setup_logging()
 
@@ -107,7 +107,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
             default=False,
             help=optparse.SUPPRESS_HELP,
         )
-        zocalo.configuration.argparse.add_env_option(self._zc, parser, default="test")
+        zocalo.configuration.argparse.add_env_option(self._zc, parser)
         self.log.debug("Launching " + str(sys.argv))
 
     def on_parsing(self, options, args):

--- a/src/zocalo/wrapper.py
+++ b/src/zocalo/wrapper.py
@@ -1,7 +1,6 @@
 import logging
 import threading
 
-import workflows
 import workflows.util
 
 import zocalo

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -183,13 +183,55 @@ def test_activate_one_environment():
     assert "live" in str(zc)
 
 
-def test_activate_multiple_environments():
+def test_activate_two_environments():
     zc = zocalo.configuration.from_string(sample_configuration)
     zc.activate_environment("partial")
     zc.activate_environment("part-2")
     assert zc.active_environments == ("partial", "part-2")
     assert "partial" in str(zc)
     assert "part-2" in str(zc)
+
+
+def test_activate_multiple_environments():
+    zc = zocalo.configuration.from_string(sample_configuration)
+    e = zc.activate(envs=["partial", "part-2"])
+    assert e == ("partial", "part-2")
+    assert zc.active_environments == ("partial", "part-2")
+    assert "partial" in str(zc)
+    assert "part-2" in str(zc)
+
+
+def test_activate_additional_environments():
+    zc = zocalo.configuration.from_string(sample_configuration)
+    zc.activate_environment("default")
+    e = zc.activate(envs=["partial", "part-2"])
+    assert e == ("partial", "part-2")
+    assert zc.active_environments == ("default", "partial", "part-2")
+    assert "partial" in str(zc)
+    assert "part-2" in str(zc)
+
+
+def test_activate_default_environment():
+    zc = zocalo.configuration.from_string(sample_configuration)
+    e = zc.activate([])
+    assert e == ("default",)
+    assert zc.active_environments == ("default",)
+    assert "default" in str(zc)
+
+
+def test_activate_call_honours_default_flag():
+    zc = zocalo.configuration.from_string(sample_configuration)
+    e = zc.activate([], default=False)
+    assert e == ()
+    assert zc.active_environments == ()
+    assert "default" not in str(zc)
+
+
+def test_activate_call_works_without_default_environment():
+    zc = zocalo.configuration.from_string("version: 1")
+    e = zc.activate([])
+    assert e == ()
+    assert zc.active_environments == ()
 
 
 @pytest.mark.parametrize("name", ("include", "environments", "version"))

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -97,8 +97,10 @@ def test_cannot_load_invalid_file(tmp_path):
 def test_loading_sample_configuration():
     zc = zocalo.configuration.from_string(sample_configuration)
 
-    assert zc.environments == frozenset({"live", "partial", "part-2", "empty"})
-    assert "4 environments" in str(zc)
+    assert zc.environments == frozenset(
+        {"live", "partial", "part-2", "empty", "alias", "default"}
+    )
+    assert "6 environments" in str(zc)
     assert "3 plugin configurations" in str(zc)
 
 
@@ -150,17 +152,19 @@ def test_cannot_load_configuration_where_environments_specifies_plugin_as_string
         )
 
 
-def test_loading_sample_configuration_get_default():
-    zc = zocalo.configuration.from_string(sample_configuration)
-    assert zc.default == "live"
-
-
 def test_cannot_activate_missing_environment():
     zc = zocalo.configuration.from_string("version: 1")
     with pytest.raises(ValueError):
         zc.activate_environment("live")
     assert zc.active_environments == ()
     assert "live" not in str(zc)
+
+
+def test_activate_an_aliased_environment():
+    zc = zocalo.configuration.from_string(sample_configuration)
+    zc.activate_environment("default")
+    assert zc.active_environments == ("default",)
+    assert "default" in str(zc)
 
 
 def test_activate_an_empty_environment():

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -29,7 +29,6 @@ sane-constants:
 
 environments:
   default: live
-
   live:
     plugins:
       - constants
@@ -37,6 +36,7 @@ environments:
   partial:
     plugins:
       - constants
+  alias: partial
   part-2:
     - sane-constants
   empty: {}

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -9,10 +9,6 @@ import zocalo.configuration
 sample_configuration = """
 version: 1
 
-defaults:
-  cli: live
-  service: partial
-
 graylog:
   plugin: graylog
   protocol: UDP
@@ -32,6 +28,8 @@ sane-constants:
   units: metric
 
 environments:
+  default: live
+
   live:
     plugins:
       - constants
@@ -132,9 +130,6 @@ def test_cannot_load_configuration_where_environments_specifies_plugin_as_string
 def test_loading_sample_configuration_get_default():
     zc = zocalo.configuration.from_string(sample_configuration)
     assert zc.default == "live"
-
-    zc = zocalo.configuration.from_string(sample_configuration, caller="service")
-    assert zc.default == "partial"
 
 
 def test_cannot_activate_missing_environment():

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -9,6 +9,10 @@ import zocalo.configuration
 sample_configuration = """
 version: 1
 
+defaults:
+  cli: live
+  service: partial
+
 graylog:
   plugin: graylog
   protocol: UDP
@@ -123,6 +127,14 @@ def test_cannot_load_configuration_where_environments_specifies_plugin_as_string
               plugin: storage
             """
         )
+
+
+def test_loading_sample_configuration_get_default():
+    zc = zocalo.configuration.from_string(sample_configuration)
+    assert zc.default == "live"
+
+    zc = zocalo.configuration.from_string(sample_configuration, caller="service")
+    assert zc.default == "partial"
 
 
 def test_cannot_activate_missing_environment():

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -114,6 +114,29 @@ def test_cannot_load_inconsistent_configuration():
         )
 
 
+def test_detect_circular_aliasing_in_environment_configuration():
+    with pytest.raises(zocalo.ConfigurationError, match="circular"):
+        zocalo.configuration.from_string(
+            """
+            version: 1
+            environments:
+              broken: circular
+              circular: broken
+            """
+        )
+
+
+def test_detect_undefined_alias_target_in_environment_configuration():
+    with pytest.raises(zocalo.ConfigurationError, match="undefined"):
+        zocalo.configuration.from_string(
+            """
+            version: 1
+            environments:
+              broken: unresolvable-alias
+            """
+        )
+
+
 def test_cannot_load_configuration_where_environments_specifies_plugin_as_string():
     with pytest.raises(zocalo.ConfigurationError, match="invalid-spec"):
         zocalo.configuration.from_string(


### PR DESCRIPTION
~~The default default is "live", which i think is sensible based on cli tools. Services default to test~~
Makes environment activation blocks consistent between go, wrap, and service instantiation. Default envs for cli tools and services can now be defined in the config under the `defaults` property.