### PR TITLE
Keep status thread alive through disconnects

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.8.1 (2021-07-08)
+------------------
+* Keep wrapper status threads alive through transport disconnection events
+
 0.8.0 (2021-05-18)
 ------------------
 * Support for Zocalo configuration files

--- a/src/zocalo/wrapper.py
+++ b/src/zocalo/wrapper.py
@@ -60,7 +60,7 @@ class StatusNotifications(threading.Thread):
     def __init__(self, send_function, taskname):
         super().__init__(name="zocalo status notification")
         self.daemon = True
-        self.send_status = send_function
+        self._send_status = send_function
         self._lock = threading.Condition(threading.Lock())
         self._status_dict = {
             "host": workflows.util.generate_unique_host_id(),
@@ -102,6 +102,12 @@ class StatusNotifications(threading.Thread):
     def shutdown(self):
         """Stop the status notification thread."""
         self._keep_running = False
+
+    def send_status(self, dictionary):
+        try:
+            self._send_status(dictionary)
+        except workflows.Disconnected:
+            pass
 
     def run(self):
         """Status notification thread main loop."""


### PR DESCRIPTION
and catch & ignore disconnection exceptions.
Status messages by themselves will not cause reconnection attempts.