### PR TITLE
Expand ~ in paths in configuration files

### DIFF
--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -369,10 +369,9 @@ def _merge_configuration(
     # Resolve all lazy file references relative to the specified context parameter
     for plugin in parsed:
         if isinstance(parsed[plugin], str):
-            parsed_plugin = (
+            parsed[plugin] = (
                 context / pathlib.Path(parsed[plugin]).expanduser()
             ).resolve()
-            parsed[plugin] = parsed_plugin
 
     # Recursively identify and merge external files (DFS)
     if parsed.get("include"):

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -369,7 +369,10 @@ def _merge_configuration(
     # Resolve all lazy file references relative to the specified context parameter
     for plugin in parsed:
         if isinstance(parsed[plugin], str):
-            parsed[plugin] = context.joinpath(parsed[plugin]).resolve()
+            parsed_plugin = (
+                context / pathlib.Path(parsed[plugin]).expanduser()
+            ).resolve()
+            parsed[plugin] = parsed_plugin
 
     # Recursively identify and merge external files (DFS)
     if parsed.get("include"):

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -371,7 +371,7 @@ def test_cannot_load_modular_configuration_with_broken_reference(tmp_path):
         )
 
 
-def test_merge_configuration_expanduser():
+def test_resolve_external_references_into_home_directory():
     merged = zocalo.configuration._merge_configuration(
         """
         version: 1

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import pathlib
 from unittest import mock
 
 import pytest
@@ -368,3 +369,19 @@ def test_cannot_load_modular_configuration_with_broken_reference(tmp_path):
               - {secondary_file}
             """
         )
+
+
+def test_merge_configuration_expanduser():
+    merged = zocalo.configuration._merge_configuration(
+        """
+        version: 1
+        foo: ~/bar.yml
+        """,
+        None,
+        pathlib.Path.cwd(),
+    )
+    assert merged == {
+        "version": 1,
+        "foo": pathlib.Path("~/bar.yml").expanduser(),
+        "environments": {},
+    }


### PR DESCRIPTION
This allows you to define e.g.:

  foo: ~/bar.yml

which will correctly get expanded to:

  foo: /path/to/home/bar.yml

instead of the current behaviour which is:

  foo: /path/to/cwd/bar.yml