### PR TITLE
New zocalo.queue_drain command

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 Unreleased
 ----------
 * New ``zocalo.shutdown`` command to shutdown Zocalo services
-* New ``zocalo.queue_drain`` command
+* New ``zocalo.queue_drain`` command to drain one queue into another in a controlled manner
 
 0.9.1 (2021-08-18)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 Unreleased
 ----------
 * New ``zocalo.shutdown`` command to shutdown Zocalo services
+* New ``zocalo.queue_drain`` command
 
 0.9.1 (2021-08-18)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,7 @@ Zocalo provides the following command line tools::
   * ``zocalo.wrap``: run a command while exposing its status to Zocalo so that it can be tracked
   * ``zocalo.service``: start a new instance of a service
   * ``zocalo.shutdown``: shutdown either specific instances of Zocalo services or all instances for a given type of service
+  * ``zocalo.queue_drain``: drain one queue into another in a controlled manner
 
 Services are available through ``zocalo.service`` if they are linked through the ``workflows.services`` entry point in ``setup.py``. For example, to start a Schlockmeister service:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,11 +40,13 @@ zip_safe = False
 [options.entry_points]
 console_scripts =
     zocalo.go = zocalo.cli.go:run
+    zocalo.queue_drain = zocalo.cli.queue_drain:run
     zocalo.service = zocalo.service:start_service
     zocalo.shutdown = zocalo.cli.shutdown:run
     zocalo.wrap = zocalo.cli.wrap:run
 libtbx.dispatcher.script =
     zocalo.go = zocalo.go
+    zocalo.queue_drain = zocalo.queue_drain
     zocalo.service = zocalo.service
     zocalo.shutdown = zocalo.shutdown
     zocalo.wrap = zocalo.wrap

--- a/src/zocalo/cli/queue_drain.py
+++ b/src/zocalo/cli/queue_drain.py
@@ -1,0 +1,160 @@
+#
+# zocalo.queue_drain
+#   Drain one queue into another in a controlled manner
+#
+
+
+import argparse
+import queue
+import sys
+import time
+from datetime import datetime
+
+import workflows.recipe.wrapper
+import workflows.transport
+
+import zocalo.configuration
+
+
+def show_cluster_info(step):
+    try:
+        print("Beamline " + step["parameters"]["cluster_project"].upper())
+    except Exception:
+        pass
+    try:
+        print("Working directory " + step["parameters"]["workingdir"])
+    except Exception:
+        pass
+
+
+show_additional_info = {"cluster.submission": show_cluster_info}
+
+
+def run():
+
+    # Load configuration
+    zc = zocalo.configuration.from_file()
+    zc.activate()
+
+    parser = argparse.ArgumentParser(
+        usage="zocalo.queue_drain [options] source destination"
+    )
+
+    default_transport = workflows.transport.default_transport
+    if (
+        zc.storage
+        and zc.storage.get("zocalo.default_transport")
+        in workflows.transport.get_known_transports()
+    ):
+        default_transport = zc.storage["zocalo.default_transport"]
+
+    parser.add_argument("-?", action="help", help=argparse.SUPPRESS)
+    parser.add_argument("SOURCE", type=str, help="Source queue name")
+    parser.add_argument("DEST", type=str, help="Destination queue name")
+    parser.add_argument(
+        "--wait",
+        action="store",
+        dest="wait",
+        type=float,
+        default=5,
+        help="Wait this many seconds between deliveries",
+    )
+    parser.add_argument(
+        "--stop",
+        action="store",
+        dest="stop",
+        type=float,
+        default=60,
+        help="Stop if no message seen for this many seconds (0 = forever)",
+    )
+    parser.add_argument(
+        "-t",
+        "--transport",
+        dest="transport",
+        metavar="TRN",
+        default=default_transport,
+        help="Transport mechanism. Known mechanisms: "
+        + ", ".join(workflows.transport.get_known_transports())
+        + f" (default: {default_transport})",
+    )
+    zc.add_command_line_options(parser)
+    workflows.transport.add_command_line_options(parser)
+    args = parser.parse_args(sys.argv[1:])
+
+    transport = workflows.transport.lookup(args.transport)()
+    transport.connect()
+
+    messages = queue.Queue()
+
+    def receive_message(header, message):
+        messages.put((header, message))
+
+    print("Reading messages from " + args.SOURCE)
+    transport.subscribe(args.SOURCE, receive_message, acknowledgement=True)
+
+    message_count = 0
+    header_filter = frozenset(
+        {
+            "content-length",
+            "destination",
+            "expires",
+            "message-id",
+            "original-destination",
+            "originalExpiration",
+            "subscription",
+            "timestamp",
+            "redelivered",
+        }
+    )
+    drain_start = time.time()
+    idle_time = 0
+    try:
+        while True:
+            try:
+                header, message = messages.get(True, 0.1)
+            except queue.Empty:
+                idle_time = idle_time + 0.1
+                if args.stop and idle_time > args.stop:
+                    break
+                continue
+            idle_time = 0
+            print()
+            try:
+                print(
+                    "Message date: {:%Y-%m-%d %H:%M:%S}".format(
+                        datetime.fromtimestamp(int(header["timestamp"]) / 1000)
+                    )
+                )
+            except Exception:
+                pass
+            try:
+                print("Recipe ID:    {}".format(message["environment"]["ID"]))
+                r = workflows.recipe.wrapper.RecipeWrapper(message=message)
+                show_additional_info.get(
+                    args.DEST, show_additional_info.get(r.recipe_step["queue"])
+                )(r.recipe_step)
+            except Exception:
+                pass
+
+            new_headers = {
+                key: header[key] for key in header if key not in header_filter
+            }
+            txn = transport.transaction_begin()
+            transport.send(args.DEST, message, headers=new_headers, transaction=txn)
+            transport.ack(header, transaction=txn)
+            transport.transaction_commit(txn)
+            message_count = message_count + 1
+            print(
+                "%4d message(s) drained in %.1f seconds"
+                % (message_count, time.time() - drain_start)
+            )
+            time.sleep(args.wait)
+    except KeyboardInterrupt:
+        sys.exit(
+            "\nCancelling, %d message(s) drained, %d message(s) unprocessed in memory"
+            % (message_count, messages.qsize())
+        )
+    print(
+        "%d message(s) drained, no message seen for %.1f seconds"
+        % (message_count, idle_time)
+    )

--- a/src/zocalo/cli/queue_drain.py
+++ b/src/zocalo/cli/queue_drain.py
@@ -30,7 +30,7 @@ def show_cluster_info(step):
 show_additional_info = {"cluster.submission": show_cluster_info}
 
 
-def run():
+def run(args=None):
 
     # Load configuration
     zc = zocalo.configuration.from_file()
@@ -79,7 +79,7 @@ def run():
     )
     zc.add_command_line_options(parser)
     workflows.transport.add_command_line_options(parser)
-    args = parser.parse_args(sys.argv[1:])
+    args = parser.parse_args(args)
 
     transport = workflows.transport.lookup(args.transport)()
     transport.connect()

--- a/tests/cli/test_queue_drain.py
+++ b/tests/cli/test_queue_drain.py
@@ -1,0 +1,51 @@
+from unittest import mock
+
+import workflows.transport
+from workflows.transport.common_transport import CommonTransport
+
+from zocalo.cli.queue_drain import run
+
+
+def test_queue_drain(mocker, capsys):
+    filtered_header = {
+        "priority": "4",
+        "workflows-recipe": "True",
+        "persistent": "true",
+    }
+
+    def mock_subscribe(source, receive_message, acknowledgement):
+        for i in range(10):
+            header = {
+                **filtered_header,
+                "content-length": "2489",
+                "expires": "0",
+                "destination": "/queue/zocalo.garbage.per_image_analysis",
+                "subscription": "1",
+                "message-id": f"ID:foo.bar.com-{i}",
+                "timestamp": "1633102156582",
+            }
+            message = {
+                "foo": f"{i}",
+            }
+            receive_message(header, message)
+
+    mocked_transport = mocker.MagicMock(CommonTransport)
+    mocker.patch.object(workflows.transport, "lookup", return_value=mocked_transport)
+    mocked_transport().subscribe = mock_subscribe
+
+    run(["source", "destination", "--wait", "0.1", "--stop", "1.5"])
+
+    captured = capsys.readouterr()
+    assert "10 message(s) drained, no message seen for" in captured.out
+
+    mocked_transport().send.assert_has_calls(
+        [
+            mock.call(
+                "destination",
+                {"foo": f"{i}"},
+                headers=filtered_header,
+                transaction=mock.ANY,
+            )
+            for i in range(10)
+        ]
+    )


### PR DESCRIPTION
To drain one queue into another in a controlled manner