### PR TITLE
New zocalo.util.rabbitmq.http_api_request()

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ Unreleased
 ----------
 * New ``zocalo.shutdown`` command to shutdown Zocalo services
 * New ``zocalo.queue_drain`` command to drain one queue into another in a controlled manner
+* New ``zocalo.util.rabbitmq.http_api_request()`` utility function to return a
+    ``urllib.request.Request`` object to query the RabbitMQ API using the credentials
+    specified via ``zocalo.configuration``.
 
 0.9.1 (2021-08-18)
 ------------------

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -1,0 +1,35 @@
+import urllib.request
+
+import zocalo.configuration
+
+
+def http_api_request(
+    zc: zocalo.configuration.Configuration,
+    api_path: str,
+) -> urllib.request.Request:
+    """
+    Return a urllib.request.Request to query the RabbitMQ HTTP API.
+
+    Credentials are obtained via zocalo.configuration.
+
+    Args:
+        zc (zocalo.configuration.Configuration): Zocalo configuration object
+        api_path (str): The path to be combined with the base_url defined by
+            the Zocalo configuration object to give the full path to the API
+            endpoint.
+    """
+    if not zc.rabbitmqapi:
+        raise zocalo.ConfigurationError(
+            "There are no RabbitMQ API credentials configured in your environment"
+        )
+    password_mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    password_mgr.add_password(
+        realm=None,
+        uri=zc.rabbitmqapi["base_url"],
+        user=zc.rabbitmqapi["username"],
+        passwd=zc.rabbitmqapi["password"],
+    )
+    handler = urllib.request.HTTPBasicAuthHandler(password_mgr)
+    opener = urllib.request.build_opener(handler)
+    urllib.request.install_opener(opener)
+    return urllib.request.Request(f"{zc.rabbitmqapi['base_url']}{api_path}")

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -1,0 +1,13 @@
+import zocalo.configuration
+from zocalo.util.rabbitmq import http_api_request
+
+
+def test_http_api_request(mocker):
+    zc = mocker.MagicMock(zocalo.configuration.Configuration)
+    zc.rabbitmqapi = {
+        "base_url": "http://rabbitmq.burrow.com:12345/api",
+        "username": "carrots",
+        "password": "carrots",
+    }
+    request = http_api_request(zc, api_path="/queues")
+    assert request.get_full_url() == "http://rabbitmq.burrow.com:12345/api/queues"


### PR DESCRIPTION
Utility function to return a `urllib.request.Request` object to query the RabbitMQ API using the credentials specified via `zocalo.configuration`.