### PR TITLE
Enable faulthandler in zocalo.wrap

### DIFF
--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -3,7 +3,7 @@
 #   Wraps a command so that its status can be tracked in zocalo
 #
 
-
+import faulthandler
 import json
 import logging
 import os
@@ -21,6 +21,7 @@ import zocalo.wrapper
 
 
 def run():
+    faulthandler.enable()
     cmdline_args = sys.argv[1:]
     # Enable logging to console
     console = logging.StreamHandler()

--- a/tests/cli/test_wrap.py
+++ b/tests/cli/test_wrap.py
@@ -2,4 +2,4 @@ import subprocess
 
 
 def test_zocalo_wrap_help():
-    subprocess.run(("zocalo.wrap", "--help"), check=True)
+    subprocess.run(("zocalo.wrap", "--help"), check=True, shell=True)

--- a/tests/cli/test_wrap.py
+++ b/tests/cli/test_wrap.py
@@ -1,0 +1,5 @@
+import subprocess
+
+
+def test_zocalo_wrap_help():
+    subprocess.run(("zocalo.wrap", "--help"), check=True)


### PR DESCRIPTION
to emit a traceback on segmentation faults and other unexpected crashes.

* [x] also write out traces on user signal