### PR TITLE
Use `argparse` for `zocalo.go` and `zocalo.wrap`

### DIFF
--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -60,7 +60,6 @@ def run():
         "--wrap",
         action="store",
         dest="wrapper",
-        type="choice",
         metavar="WRAP",
         default=None,
         choices=list(known_wrappers),

--- a/tests/cli/test_wrap.py
+++ b/tests/cli/test_wrap.py
@@ -2,4 +2,4 @@ import subprocess
 
 
 def test_zocalo_wrap_help():
-    subprocess.run(("zocalo.wrap", "--help"), check=True, shell=True)
+    subprocess.run(("zocalo.wrap", "--help"), check=True)

--- a/tests/cli/test_wrap.py
+++ b/tests/cli/test_wrap.py
@@ -1,5 +1,6 @@
 import subprocess
+import sys
 
 
 def test_zocalo_wrap_help():
-    subprocess.run(("zocalo.wrap", "--help"), check=True)
+    subprocess.run(("zocalo.wrap", "--help"), check=True, shell=sys.platform == "win32")


### PR DESCRIPTION
This brings them in to line with the rest of the Zocalo command line tools. Changes are also made to reflect DiamondLightSource/python-workflows#76