### PR TITLE
Drop Python 3.6 and 3.7 support

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -19,10 +19,10 @@ stages:
       - task: UsePythonVersion@0
         displayName: Set up python
         inputs:
-          versionSpec: 3.6
+          versionSpec: 3.8
 
       - bash: python .azure-pipelines/syntax-validation.py
-        displayName: Syntax validation (3.6)
+        displayName: Syntax validation (3.8)
 
       - task: UsePythonVersion@0
         displayName: Set up python
@@ -50,7 +50,7 @@ stages:
       - task: UsePythonVersion@0
         displayName: Set up python
         inputs:
-          versionSpec: 3.9
+          versionSpec: 3.10
 
       - bash: |
           pip install --disable-pip-version-check collective.checkdocs wheel
@@ -86,10 +86,6 @@ stages:
       vmImage: ubuntu-20.04
     strategy:
       matrix:
-        python36:
-          PYTHON_VERSION: 3.6
-        python37:
-          PYTHON_VERSION: 3.7
         python38:
           PYTHON_VERSION: 3.8
         python39:
@@ -103,10 +99,6 @@ stages:
       vmImage: macOS-latest
     strategy:
       matrix:
-        python36:
-          PYTHON_VERSION: 3.6
-        python37:
-          PYTHON_VERSION: 3.7
         python38:
           PYTHON_VERSION: 3.8
         python39:
@@ -120,10 +112,6 @@ stages:
       vmImage: windows-latest
     strategy:
       matrix:
-        python36:
-          PYTHON_VERSION: 3.6
-        python37:
-          PYTHON_VERSION: 3.7
         python38:
           PYTHON_VERSION: 3.8
         python39:
@@ -149,7 +137,7 @@ stages:
       - task: UsePythonVersion@0
         displayName: Set up python
         inputs:
-          versionSpec: 3.9
+          versionSpec: 3.10
 
       - task: DownloadBuildArtifacts@0
         displayName: Get pre-built package

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased
 ----------
+* Drop support for Python 3.6 and 3.7
 
 0.11.1 (2021-11-08)
 -------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -37,7 +35,7 @@ install_requires =
 packages = find:
 package_dir =
     =src
-python_requires = >=3.6
+python_requires = >=3.8
 zip_safe = False
 
 [options.entry_points]


### PR DESCRIPTION
Will be required for #142. Conda-forge have dropped 3.6, and we never really used 3.7, so the impact of this might be rather low? Don't know about ESRF.