### PR TITLE
Add support for bindings to `RabbitMQAPI`

### DIFF
--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -287,6 +287,33 @@ class NodeInfo(BaseModel):
     # binary	Detailed breakdown of the owners of binary memory. Only appears if ?binary=true is appended to the URL. Note that this can be an expensive query if there are many small binaries in the system.
 
 
+class DestinationType(enum.Enum):
+    q = "queue"
+    e = "exchange"
+
+
+class BindingSpec(BaseModel):
+    source: str = Field(
+        ..., description="The name of the source exchange of the binding"
+    )
+    destination: str = Field(
+        ...,
+        description="The name of the end point of the binding (either an exchange or a queue)",
+    )
+    destination_type: DestinationType = Field(
+        ..., description="The type of the binding end point"
+    )
+    vhost: str = Field(
+        ..., description="Virtual host name with non-ASCII characters escaped as in C."
+    )
+    routing_key: str = Field("", description="Routing key attached to binding")
+
+
+class BindingInfo(BindingSpec):
+    arguments: Optional[dict] = Field(None)
+    properties_key: str = Field("~")
+
+
 class ExchangeType(enum.Enum):
     direct = "direct"
     topic = "topic"
@@ -624,9 +651,49 @@ class RabbitMQAPI:
             f"{self._url}/{endpoint}", auth=self._auth, params=params, json=json
         )
 
+    def post(
+        self,
+        endpoint: str,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+    ) -> requests.Response:
+        return requests.post(
+            f"{self._url}/{endpoint}", auth=self._auth, data=data, json=json
+        )
+
     def delete(self, endpoint: str, params: Dict[str, Any] = None) -> requests.Response:
         return requests.delete(
             f"{self._url}/{endpoint}", auth=self._auth, params=params
+        )
+
+    def bindings(
+        self,
+        vhost: Optional[str] = None,
+        source: Optional[str] = None,
+        destination: Optional[str] = None,
+        destination_type: Optional[str] = None,
+    ) -> List[BindingInfo]:
+        endpoint = "bindings"
+        if vhost is not None:
+            endpoint = f"{endpoint}/{vhost}"
+        _check = (source, destination, destination_type)
+        if not all(_ is None for _ in _check) and None in _check:
+            raise ValueError(
+                "Either all of source, destination and destination_type must be specified, or none of them"
+            )
+        if source is not None:
+            endpoint = f"{endpoint}/e/{source}/{destination_type}/{destination}"
+        response = self.get(endpoint)
+        return [BindingInfo(**bi) for bi in response.json()]
+
+    def binding_declare(self, binding: BindingSpec):
+        endpoint = f"bindings/{binding.vhost}/e/{binding.source}/{binding.destination_type.name}/{binding.destination}"
+        self.post(
+            endpoint,
+            json=binding.dict(
+                exclude_defaults=True,
+                exclude={"vhost", "source", "destination", "destination_type"},
+            ),
         )
 
     def connections(

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -288,8 +288,8 @@ class NodeInfo(BaseModel):
 
 
 class DestinationType(enum.Enum):
-    q = "queue"
-    e = "exchange"
+    QUEUE = "q"
+    EXCHANGE = "e"
 
 
 class BindingSpec(BaseModel):
@@ -675,7 +675,7 @@ class RabbitMQAPI:
         vhost: Optional[str] = None,
         source: Optional[str] = None,
         destination: Optional[str] = None,
-        destination_type: Optional[DestinationType] = None,
+        destination_type: Optional[str] = None,
     ) -> List[BindingInfo]:
         endpoint = "bindings"
         if vhost is not None:
@@ -686,12 +686,12 @@ class RabbitMQAPI:
                 "Either all of source, destination and destination_type must be specified, or none of them"
             )
         if destination_type is not None:
-            endpoint = f"{endpoint}/e/{source}/{destination_type.name}/{destination}"
+            endpoint = f"{endpoint}/e/{source}/{destination_type}/{destination}"
         response = self.get(endpoint)
         return [BindingInfo(**bi) for bi in response.json()]
 
     def binding_declare(self, binding: BindingSpec):
-        endpoint = f"bindings/{binding.vhost}/e/{binding.source}/{binding.destination_type.name}/{binding.destination}"
+        endpoint = f"bindings/{binding.vhost}/e/{binding.source}/{binding.destination_type.value}/{binding.destination}"
         self.post(
             endpoint,
             json=binding.dict(
@@ -705,12 +705,12 @@ class RabbitMQAPI:
         vhost: str,
         source: str,
         destination: str,
-        destination_type: DestinationType,
+        destination_type: str,
         properties_key: Optional[str] = None,
     ):
         # If properties_key is not specified then all bindings between the specified
         # source and destination are deleted
-        endpoint = f"bindings/{vhost}/e/{source}/{destination_type.name}/{destination}"
+        endpoint = f"bindings/{vhost}/e/{source}/{destination_type}/{destination}"
         if properties_key is None:
             props = [BindingInfo(**r).properties_key for r in self.get(endpoint).json()]
         else:

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -307,10 +307,10 @@ class BindingSpec(BaseModel):
         ..., description="Virtual host name with non-ASCII characters escaped as in C."
     )
     routing_key: str = Field("", description="Routing key attached to binding")
+    arguments: Optional[dict] = Field(None, description="Binding arguments")
 
 
 class BindingInfo(BindingSpec):
-    arguments: Optional[dict] = Field(None, description="Binding arguments")
     properties_key: str = Field(
         "",
         description="Unique identifier composed of the bindings routing key and a hash of its arguments",
@@ -674,7 +674,7 @@ class RabbitMQAPI:
         vhost: Optional[str] = None,
         source: Optional[str] = None,
         destination: Optional[str] = None,
-        destination_type: Optional[str] = None,
+        destination_type: Optional[DestinationType] = None,
     ) -> List[BindingInfo]:
         endpoint = "bindings"
         if vhost is not None:
@@ -684,8 +684,8 @@ class RabbitMQAPI:
             raise ValueError(
                 "Either all of source, destination and destination_type must be specified, or none of them"
             )
-        if source is not None:
-            endpoint = f"{endpoint}/e/{source}/{destination_type}/{destination}"
+        if destination_type is not None:
+            endpoint = f"{endpoint}/e/{source}/{destination_type.name}/{destination}"
         response = self.get(endpoint)
         return [BindingInfo(**bi) for bi in response.json()]
 

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -308,13 +308,14 @@ class BindingSpec(BaseModel):
     )
     routing_key: str = Field("", description="Routing key attached to binding")
     arguments: Optional[dict] = Field(None, description="Binding arguments")
-
-
-class BindingInfo(BindingSpec):
     properties_key: str = Field(
         "",
         description="Unique identifier composed of the bindings routing key and a hash of its arguments",
     )
+
+
+class BindingInfo(BindingSpec):
+    pass
 
 
 class ExchangeType(enum.Enum):

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -680,8 +680,8 @@ class RabbitMQAPI:
         endpoint = "bindings"
         if vhost is not None:
             endpoint = f"{endpoint}/{vhost}"
-        _check = (source, destination, destination_type)
-        if not all(_ is None for _ in _check) and None in _check:
+        _check = {source, destination, destination_type}
+        if None in _check and len(_check) > 1:
             raise ValueError(
                 "Either all of source, destination and destination_type must be specified, or none of them"
             )

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -696,6 +696,16 @@ class RabbitMQAPI:
             ),
         )
 
+    def binding_delete(
+        self,
+        vhost: str,
+        source: str,
+        destination: str,
+        destination_type: DestinationType,
+    ):
+        endpoint = f"bindings/{vhost}/e/{source}/{destination_type.name}/{destination}"
+        self.delete(endpoint)
+
     def connections(
         self, name: Optional[str] = None
     ) -> Union[List[ConnectionInfo], ConnectionInfo]:

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -719,7 +719,7 @@ class RabbitMQAPI:
             resp = self.delete(f"{endpoint}/{prop}")
             if resp.status_code == 404:
                 logger.error(f"404 not found when deleting {endpoint}/{prop}")
-            if resp.status_code == 405:
+            elif resp.status_code == 405:
                 logger.error(f"405 not allowed to delete {endpoint}/{prop}")
 
     def connections(

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -132,7 +132,7 @@ def test_api_bindings(requests_mock, rmqapi):
     binding = {
         "source": "foo",
         "destination": "bar",
-        "destination_type": "queue",
+        "destination_type": "q",
         "arguments": {},
         "routing_key": "bar",
         "properties_key": "bar",
@@ -154,7 +154,7 @@ def test_api_bindings(requests_mock, rmqapi):
             vhost="zocalo",
             source=binding["source"],
             destination=binding["destination"],
-            destination_type=rabbitmq.DestinationType("queue"),
+            destination_type="q",
         )
         == [rabbitmq.BindingInfo(**binding)]
     )
@@ -165,7 +165,7 @@ def binding_spec():
     return rabbitmq.BindingSpec(
         source="foo",
         destination="bar",
-        destination_type=rabbitmq.DestinationType("queue"),
+        destination_type="q",
         arguments={},
         routing_key="bar",
         vhost="zocalo",
@@ -189,7 +189,7 @@ def test_api_bindings_delete(requests_mock, rmqapi, binding_spec):
     binding = {
         "source": "foo",
         "destination": "bar",
-        "destination_type": "queue",
+        "destination_type": "q",
         "arguments": {},
         "routing_key": "bar",
         "properties_key": "bar",
@@ -201,7 +201,7 @@ def test_api_bindings_delete(requests_mock, rmqapi, binding_spec):
         vhost="zocalo",
         source="foo",
         destination="bar",
-        destination_type=rabbitmq.DestinationType("queue"),
+        destination_type="q",
     )
     assert requests_mock.call_count == 2
     history = requests_mock.request_history[0]

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -128,6 +128,90 @@ def test_api_queue_delete(requests_mock, rmqapi, queue_spec):
     assert history.url.endswith("/api/queues/zocalo/foo?if_unused=True&if_empty=True")
 
 
+def test_api_bindings(requests_mock, rmqapi):
+    binding = {
+        "source": "foo",
+        "destination": "bar",
+        "destination_type": "queue",
+        "arguments": {},
+        "routing_key": "bar",
+        "properties_key": "bar",
+        "vhost": "zocalo",
+    }
+
+    requests_mock.get("/api/bindings", json=[binding])
+    assert rmqapi.bindings() == [rabbitmq.BindingInfo(**binding)]
+
+    requests_mock.get("/api/bindings/zocalo", json=[binding])
+    assert rmqapi.bindings(vhost="zocalo") == [rabbitmq.BindingInfo(**binding)]
+
+    requests_mock.get(
+        f"/api/bindings/zocalo/e/{binding['source']}/q/{binding['destination']}",
+        json=[binding],
+    )
+    assert (
+        rmqapi.bindings(
+            vhost="zocalo",
+            source=binding["source"],
+            destination=binding["destination"],
+            destination_type=rabbitmq.DestinationType("queue"),
+        )
+        == [rabbitmq.BindingInfo(**binding)]
+    )
+
+
+@pytest.fixture
+def binding_spec():
+    return rabbitmq.BindingSpec(
+        source="foo",
+        destination="bar",
+        destination_type=rabbitmq.DestinationType("queue"),
+        arguments={},
+        routing_key="bar",
+        vhost="zocalo",
+    )
+
+
+def test_api_binding_declare(requests_mock, rmqapi, binding_spec):
+    requests_mock.post("/api/bindings/zocalo/e/foo/q/bar")
+    rmqapi.binding_declare(binding=binding_spec)
+    assert requests_mock.call_count == 1
+    history = requests_mock.request_history[0]
+    assert history.method == "POST"
+    assert history.url.endswith("/api/bindings/zocalo/e/foo/q/bar")
+    assert history.json() == {
+        "arguments": binding_spec.arguments,
+        "routing_key": "bar",
+    }
+
+
+def test_api_bindings_delete(requests_mock, rmqapi, binding_spec):
+    binding = {
+        "source": "foo",
+        "destination": "bar",
+        "destination_type": "queue",
+        "arguments": {},
+        "routing_key": "bar",
+        "properties_key": "bar",
+        "vhost": "zocalo",
+    }
+    requests_mock.get("/api/bindings/zocalo/e/foo/q/bar", json=[binding])
+    requests_mock.delete("/api/bindings/zocalo/e/foo/q/bar/bar")
+    rmqapi.bindings_delete(
+        vhost="zocalo",
+        source="foo",
+        destination="bar",
+        destination_type=rabbitmq.DestinationType("queue"),
+    )
+    assert requests_mock.call_count == 2
+    history = requests_mock.request_history[0]
+    assert history.method == "GET"
+    assert history.url.endswith("/api/bindings/zocalo/e/foo/q/bar")
+    history = requests_mock.request_history[1]
+    assert history.method == "DELETE"
+    assert history.url.endswith("/api/bindings/zocalo/e/foo/q/bar/bar")
+
+
 def test_api_nodes(requests_mock, rmqapi):
     node = {
         "name": "rabbit@pooter123",


### PR DESCRIPTION
Bindings are handled slightly differently to queues and exchanges in the RabbitMQ HTTP API. A `POST` is required rather than a `PUT` to the address `api/bindings/e/{exchange name}/{e, q}/{queue or exchange name}`. The `routing_key` and `arguments` can be declared in the body and a "name" (called the `properties_key`) is then created for the binding from the `routing_key` and a hash of `arguments`. A single binding can then be found at `api/bindings/e/{exchange name}/{e, q}/{queue or exchange name}/{properties_key}`. The proposed API allows for deletion of a single binding if `properties_key` is specified or of all bindings between a given source and destination otherwise.

Resolves #145 