### PR TITLE
Fix for bindings API support

### DIFF
--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -688,7 +688,11 @@ class RabbitMQAPI:
         if destination_type is not None:
             endpoint = f"{endpoint}/e/{source}/{destination_type}/{destination}"
         response = self.get(endpoint)
-        return [BindingInfo(**bi) for bi in response.json()]
+        naming_map = {"queue": "q", "exchange": "e"}
+        response_json = response.json()
+        for bi in response_json:
+            bi["destination_type"] = naming_map[bi["destination_type"]]
+        return [BindingInfo(**bi) for bi in response_json]
 
     def binding_declare(self, binding: BindingSpec):
         endpoint = f"bindings/{binding.vhost}/e/{binding.source}/{binding.destination_type.value}/{binding.destination}"

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -685,14 +685,13 @@ class RabbitMQAPI:
             raise ValueError(
                 "Either all of source, destination and destination_type must be specified, or none of them"
             )
+        naming_map = {"queue": "q", "exchange": "e"}
         if destination_type is not None:
             endpoint = f"{endpoint}/e/{source}/{destination_type}/{destination}"
-        response = self.get(endpoint)
-        naming_map = {"queue": "q", "exchange": "e"}
-        response_json = response.json()
-        for bi in response_json:
+        response = self.get(endpoint).json()
+        for bi in response:
             bi["destination_type"] = naming_map[bi["destination_type"]]
-        return [BindingInfo(**bi) for bi in response_json]
+        return [BindingInfo(**bi) for bi in response]
 
     def binding_declare(self, binding: BindingSpec):
         endpoint = f"bindings/{binding.vhost}/e/{binding.source}/{binding.destination_type.value}/{binding.destination}"

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -685,13 +685,16 @@ class RabbitMQAPI:
             raise ValueError(
                 "Either all of source, destination and destination_type must be specified, or none of them"
             )
-        naming_map = {"queue": "q", "exchange": "e"}
         if destination_type is not None:
             endpoint = f"{endpoint}/e/{source}/{destination_type}/{destination}"
-        response = self.get(endpoint).json()
-        for bi in response:
-            bi["destination_type"] = naming_map[bi["destination_type"]]
-        return [BindingInfo(**bi) for bi in response]
+        dest_map = {"queue": "q", "exchange": "e"}
+        conv = (
+            lambda key, value: dest_map[value] if key == "destination_type" else value
+        )
+        return [
+            BindingInfo(**{_r[0]: conv(_r[0], _r[1]) for _r in r.items()})
+            for r in self.get(endpoint).json()
+        ]
 
     def binding_declare(self, binding: BindingSpec):
         endpoint = f"bindings/{binding.vhost}/e/{binding.source}/{binding.destination_type.value}/{binding.destination}"
@@ -715,7 +718,18 @@ class RabbitMQAPI:
         # source and destination are deleted
         endpoint = f"bindings/{vhost}/e/{source}/{destination_type}/{destination}"
         if properties_key is None:
-            props = [BindingInfo(**r).properties_key for r in self.get(endpoint).json()]
+            dest_map = {"queue": "q", "exchange": "e"}
+            conv = (
+                lambda key, value: dest_map[value]
+                if key == "destination_type"
+                else value
+            )
+            props = [
+                BindingInfo(
+                    **{_r[0]: conv(_r[0], _r[1]) for _r in r.items()}
+                ).properties_key
+                for r in self.get(endpoint).json()
+            ]
         else:
             props = [properties_key]
         for prop in props:

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -138,16 +138,25 @@ def test_api_bindings(requests_mock, rmqapi):
         "properties_key": "bar",
         "vhost": "zocalo",
     }
+    response = {
+        "source": "foo",
+        "destination": "bar",
+        "destination_type": "queue",
+        "arguments": {},
+        "routing_key": "bar",
+        "properties_key": "bar",
+        "vhost": "zocalo",
+    }
 
-    requests_mock.get("/api/bindings", json=[binding])
+    requests_mock.get("/api/bindings", json=[response])
     assert rmqapi.bindings() == [rabbitmq.BindingInfo(**binding)]
 
-    requests_mock.get("/api/bindings/zocalo", json=[binding])
+    requests_mock.get("/api/bindings/zocalo", json=[response])
     assert rmqapi.bindings(vhost="zocalo") == [rabbitmq.BindingInfo(**binding)]
 
     requests_mock.get(
         f"/api/bindings/zocalo/e/{binding['source']}/q/{binding['destination']}",
-        json=[binding],
+        json=[response],
     )
     assert (
         rmqapi.bindings(

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -198,7 +198,7 @@ def test_api_bindings_delete(requests_mock, rmqapi, binding_spec):
     binding = {
         "source": "foo",
         "destination": "bar",
-        "destination_type": "q",
+        "destination_type": "queue",
         "arguments": {},
         "routing_key": "bar",
         "properties_key": "bar",


### PR DESCRIPTION
When constructing a url to point to a binding queues and exchanges are denoted by `q` and `e` respectively. However, when binding information is returned in response to a `GET` request the `destination_type` is labelled as either `queue` or `exchange`. The result from the `GET` request then needs to be mapped to `q` or `e` for consistency and to correctly fill the `destination_type` field in `BindingInfo`.