### PR TITLE
Fix `zocalo.dlq_purge` for RabbitMQ

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Unreleased
 * ``zocalo.queue_drain`` now allows the automatic determination
   of destination queues for recipe messages
 * ``zocalo.queue_drain`` fixed for use in a RabbitMQ environment
+* ``zocalo.dlq_purge`` fixed for use in a RabbitMQ environment
 
 0.12.0 (2021-11-15)
 -------------------

--- a/tests/cli/test_dlq_purge.py
+++ b/tests/cli/test_dlq_purge.py
@@ -82,7 +82,6 @@ def test_dlq_purge_rabbitmq(mocker, tmp_path):
         [
             mock.call(
                 gen_header_rabbitmq(i, use_datetime=False),
-                subscription_id=1,
             )
             for i in range(10)
         ]

--- a/tests/cli/test_dlq_purge.py
+++ b/tests/cli/test_dlq_purge.py
@@ -25,7 +25,8 @@ def gen_header_rabbitmq(i, use_datetime=True):
     if use_datetime:
         tstamp = datetime.fromtimestamp(tstamp)
     return {
-        "headers": {"x-death": [{"time": tstamp}]},
+        "x-death": [{"time": tstamp}],
+        "subscription": 1,
         "message-id": f"ID:foo.bar.com-{i}",
     }
 
@@ -81,7 +82,7 @@ def test_dlq_purge_rabbitmq(mocker, tmp_path):
         [
             mock.call(
                 gen_header_rabbitmq(i, use_datetime=False),
-                subscription_id=f"ID:foo.bar.com-{i}",
+                subscription_id=1,
             )
             for i in range(10)
         ]


### PR DESCRIPTION
Make changes necessary for `workflows>2.16` and add support for purging all queues on RabbitMQ.