### PR TITLE
Fix `RabbitMQAPI.users()`

### DIFF
--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -548,7 +548,16 @@ class HashingAlgorithm(enum.Enum):
     rabbit_password_hashing_md5 = "rabbit_password_hashing_md5"
 
 
-class UserSpec(BaseModel):
+class UserBase(BaseModel):
+    name: str = Field(..., description="Username")
+    password_hash: str = Field(..., description="Hash of the user password.")
+    hashing_algorithm: HashingAlgorithm
+
+    class Config:
+        use_enum_values = True
+
+
+class UserSpec(UserBase):
     """
     The tags key is mandatory.
     Either password or password_hash can be set.If neither are set the user will not be
@@ -562,16 +571,10 @@ class UserSpec(BaseModel):
     rabbit_password_hashing_md5.
     """
 
-    name: str = Field(..., description="Username")
-    password_hash: str = Field(..., description="Hash of the user password.")
-    hashing_algorithm: HashingAlgorithm
-    tags: Union[str, List[str]]
-
-    class Config:
-        use_enum_values = True
+    tags: str
 
 
-class UserInfo(UserSpec):
+class UserInfo(UserBase):
     tags: List[str]
 
 

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -565,14 +565,14 @@ class UserSpec(BaseModel):
     name: str = Field(..., description="Username")
     password_hash: str = Field(..., description="Hash of the user password.")
     hashing_algorithm: HashingAlgorithm
-    tags: str
+    tags: Union[str, List[str]]
 
     class Config:
         use_enum_values = True
 
 
 class UserInfo(UserSpec):
-    pass
+    tags: List[str]
 
 
 def http_api_request(
@@ -841,7 +841,7 @@ class RabbitMQAPI:
         endpoint = f"queues/{vhost}/{name}"
         self.delete(endpoint, params={"if_unused": if_unused, "if_empty": if_empty})
 
-    def users(self, name: str = None) -> Union[List[UserInfo], UserInfo]:
+    def users(self, name: Optional[str] = None) -> Union[List[UserInfo], UserInfo]:
         endpoint = "users"
         if name:
             endpoint = f"{endpoint}/{name}/"

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -360,7 +360,7 @@ def test_api_users(requests_mock, rmqapi):
         "name": "guest",
         "password_hash": "guest",
         "hashing_algorithm": "rabbit_password_hashing_sha256",
-        "tags": "administrator",
+        "tags": ["administrator"],
     }
 
     # First call rmq.users() with defaults


### PR DESCRIPTION
User tags are specified as a comma separated string but are returned by the management API as a list. 

As `UserInfo` inherits from `UserSpec` and `mypy` won't like a type change from `str` to `list` in a subclass I've made the type of tags in `UserSpec` `Union[str, List[str]]`. Unsure if that is the best solution.