### PR TITLE
Add user removal to RabbitMQ configuration tool

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 Unreleased
 ----------
+* Fix for getting user information from the RabbitMQ management API 
+* Add user removal to RabbitMQ configuration command line tool
 
 0.13.0 (2021-12-01)
 -------------------

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -84,13 +84,13 @@ class _RabbitMQAPI(RabbitMQAPI):
 
 
 @functools.singledispatch
-def _info_to_spec(infos: list, incoming):
+def _info_to_spec(incoming, infos: list):
     cls = type(incoming)
     return [cls(**i.dict()) for i in infos]
 
 
 @_info_to_spec.register  # type: ignore
-def _(infos: list, incoming: UserSpec):
+def _(incoming: UserSpec, infos: list):
     cls = type(incoming)
 
     def _dict(info: UserInfo) -> dict:
@@ -124,7 +124,7 @@ def _(comp: BindingSpec) -> bool:
 
 def update_config(api: _RabbitMQAPI, incoming, current):
     cls = type(incoming[0])
-    current = _info_to_spec(current, incoming[0])
+    current = _info_to_spec(incoming[0], current)
     for cc in current:
         if cc in incoming:
             if hasattr(cc, "name"):
@@ -281,7 +281,10 @@ def run():
     try:
         rmq_config = zc.storage["zocalo.rabbitmq_user_config"]
     except Exception as e:
-        print(e.message, e.args)
+        logger.error(
+            "Problem with Zocalo configuration file. Possibly zocalo.rabbitmq_user_config storage plugin is missing"
+        )
+        raise e
     args = parser.parse_args()
     rmq_config_file = args.config_file
     seed = args.seed

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -13,20 +13,14 @@ import yaml
 from pydantic import BaseModel
 
 import zocalo.configuration
-from zocalo.util.rabbitmq import (
-    BindingSpec,
-    ExchangeSpec,
-    PolicySpec,
-    QueueSpec,
-    RabbitMQAPI,
-    UserInfo,
-    UserSpec,
-)
+from zocalo.util.rabbitmq import BindingSpec, ExchangeSpec, PolicySpec, QueueSpec
+from zocalo.util.rabbitmq import RabbitMQAPI as _RabbitMQAPI
+from zocalo.util.rabbitmq import UserInfo, UserSpec
 
 logger = logging.getLogger("zocalo.cli.configure_rabbitmq")
 
 
-class _RabbitMQAPI(RabbitMQAPI):
+class RabbitMQAPI(_RabbitMQAPI):
     @functools.singledispatchmethod  # type: ignore
     def create_component(self, component: BaseModel):
         raise NotImplementedError(f"Component {component} not recognised")
@@ -124,7 +118,7 @@ def _(comp: BindingSpec) -> bool:
 
 
 def update_config(
-    api: _RabbitMQAPI, incoming: List[BaseModel], current: List[BaseModel]
+    api: RabbitMQAPI, incoming: List[BaseModel], current: List[BaseModel]
 ):
     cls = type(incoming[0])
     current = _info_to_spec(incoming[0], current)
@@ -280,7 +274,7 @@ def run():
         dest="seed",
         help="Seed used in random salt generation for password hashing",
     )
-    api = _RabbitMQAPI.from_zocalo_configuration(zc)
+    api = RabbitMQAPI.from_zocalo_configuration(zc)
     try:
         rmq_config = zc.storage["zocalo.rabbitmq_user_config"]
     except Exception as e:

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import yaml
+from pydantic import BaseModel
 
 import zocalo.configuration
 from zocalo.util.rabbitmq import (
@@ -27,11 +28,11 @@ logger = logging.getLogger("zocalo.cli.configure_rabbitmq")
 
 class _RabbitMQAPI(RabbitMQAPI):
     @functools.singledispatchmethod  # type: ignore
-    def create_component(self, component):
+    def create_component(self, component: BaseModel):
         raise NotImplementedError(f"Component {component} not recognised")
 
     @functools.singledispatchmethod  # type: ignore
-    def delete_component(self, component):
+    def delete_component(self, component: BaseModel):
         raise NotImplementedError(f"Component {component} not recognised")
 
     @create_component.register  # type: ignore
@@ -90,7 +91,7 @@ def _info_to_spec(incoming, infos: list):
 
 
 @_info_to_spec.register  # type: ignore
-def _(incoming: UserSpec, infos: list):
+def _(incoming: UserSpec, infos: List[UserInfo]):
     cls = type(incoming)
 
     def _dict(info: UserInfo) -> dict:
@@ -122,7 +123,9 @@ def _(comp: BindingSpec) -> bool:
     return False
 
 
-def update_config(api: _RabbitMQAPI, incoming, current):
+def update_config(
+    api: _RabbitMQAPI, incoming: List[BaseModel], current: List[BaseModel]
+):
     cls = type(incoming[0])
     current = _info_to_spec(incoming[0], current)
     for cc in current:


### PR DESCRIPTION
The random salt used in password hashing is now seeded via a command line argument to make the hash reproducible so that a regularly run configurator doesn't detect a hashed password change and delete and recreate the users every time it runs. 