### PR TITLE
zocalo.dlq_purge/reinject updates

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased
 ----------
+* Minor fixes in ``zocalo.dlq_*`` commands
 
 0.13.0 (2021-12-01)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,10 @@ History
 
 Unreleased
 ----------
-* Minor fixes in ``zocalo.dlq_*`` commands
+* ``zocalo.dlq_purge`` offers a ``--location`` flag to override where files are
+  being written
+* ``zocalo.dlq_reinject`` can again understand ``zocalo.dlq_purge`` output
+  passed on stdin
 
 0.13.0 (2021-12-01)
 -------------------

--- a/src/zocalo/cli/dlq_purge.py
+++ b/src/zocalo/cli/dlq_purge.py
@@ -46,7 +46,7 @@ def run() -> None:
     )
     zc.add_command_line_options(parser)
     workflows.transport.add_command_line_options(parser, transport_argument=True)
-    print(sys.argv)
+
     args = parser.parse_args(["--stomp-prfx=DLQ"] + sys.argv[1:])
     if args.transport == "PikaTransport":
         queues = ["dlq." + a for a in args.queues]
@@ -106,7 +106,7 @@ def run() -> None:
         with open(os.path.join(filepath, filename), "w") as fh:
             fh.write(json.dumps(dlqmsg, indent=2, sort_keys=True))
         print(
-            f"Message {header['message-id']} ({time.strftime('%Y-%m-%d %H:%M:%S', timestamp)}) exported:\n {os.path.join(filepath, filename)}"
+            f"Message {header['message-id']} ({time.strftime('%Y-%m-%d %H:%M:%S', timestamp)}) exported:\n  {os.path.join(filepath, filename)}"
         )
         transport.ack(header)
         idlequeue.put_nowait("done")

--- a/src/zocalo/cli/dlq_purge.py
+++ b/src/zocalo/cli/dlq_purge.py
@@ -4,11 +4,9 @@
 #   in a temporary directory.
 #
 
-
 import argparse
-import errno
 import json
-import os
+import pathlib
 import queue
 import re
 import sys
@@ -31,13 +29,24 @@ def run() -> None:
 
     parser.add_argument("-?", action="help", help=argparse.SUPPRESS)
     dlqprefix = "zocalo"
-    # override default stomp host
     parser.add_argument(
         "--wait",
         action="store",
         dest="wait",
         type=float,
-        help="Wait this many seconds for ActiveMQ replies",
+        help="Wait this many seconds for incoming messages",
+    )
+    if zc.storage and zc.storage.get("zocalo.dlq.purge_location"):
+        dlq_dump_path = zc.storage["zocalo.dlq.purge_location"]
+    else:
+        dlq_dump_path = "./DLQ"
+    parser.add_argument(
+        "--location",
+        action="store",
+        dest="location",
+        type=str,
+        default=dlq_dump_path,
+        help=f"Where to write out DLQ message files (default: {dlq_dump_path})",
     )
     parser.add_argument(
         "queues",
@@ -54,11 +63,6 @@ def run() -> None:
         queues = args.queues
     transport = workflows.transport.lookup(args.transport)()
 
-    if zc.storage and zc.storage.get("zocalo.dlq.purge_location"):
-        dlq_dump_path = zc.storage["zocalo.dlq.purge_location"]
-    else:
-        dlq_dump_path = "./DLQ"
-
     characterfilter = re.compile(r"[^a-zA-Z0-9._-]+", re.UNICODE)
     idlequeue: queue.Queue = queue.Queue()
 
@@ -73,26 +77,14 @@ def run() -> None:
             msg_time = int(header["timestamp"])
         timestamp = time.localtime(msg_time / 1000)
         millisec = msg_time % 1000
-        filepath = os.path.join(
-            dlq_dump_path,
-            time.strftime("%Y-%m-%d", timestamp),
-            #       time.strftime('%H-%M', timestamp),
-        )
-        filename = (
+        filepath = pathlib.Path(args.location, time.strftime("%Y-%m-%d", timestamp))
+        filepath.mkdir(parents=True, exist_ok=True)
+        filename = filepath / (
             "msg-"
             + time.strftime("%Y%m%d-%H%M%S", timestamp)
-            + "-"
-            + "%03d" % millisec
-            + "-"
+            + f"-{millisec:03d}-"
             + characterfilter.sub("_", str(header["message-id"]))
         )
-        try:
-            os.makedirs(filepath)
-        except OSError as exc:
-            if exc.errno == errno.EEXIST and os.path.isdir(filepath):
-                pass
-            else:
-                raise
 
         dlqmsg = {
             "exported": {
@@ -103,10 +95,10 @@ def run() -> None:
             "message": message,
         }
 
-        with open(os.path.join(filepath, filename), "w") as fh:
-            fh.write(json.dumps(dlqmsg, indent=2, sort_keys=True))
+        with filename.open("w") as fh:
+            json.dump(dlqmsg, fh, indent=2, sort_keys=True)
         print(
-            f"Message {header['message-id']} ({time.strftime('%Y-%m-%d %H:%M:%S', timestamp)}) exported:\n  {os.path.join(filepath, filename)}"
+            f"Message {header['message-id']} ({time.strftime('%Y-%m-%d %H:%M:%S', timestamp)}) exported:\n  {filename}"
         )
         transport.ack(header)
         idlequeue.put_nowait("done")

--- a/src/zocalo/cli/dlq_reinject.py
+++ b/src/zocalo/cli/dlq_reinject.py
@@ -69,7 +69,8 @@ def run() -> None:
     transport = workflows.transport.lookup(args.transport)()
 
     stdin = []
-    if select.select([sys.stdin], [], [], 0.0)[0]:
+    stdin_fileno = getattr(sys.stdin, "fileno", lambda: None)()
+    if isinstance(stdin_fileno, int) and select.select([sys.stdin], [], [], 0.0)[0]:
         dlq_purge_filename_format = re.compile(r"^  \/")
         while True:
             line = sys.stdin.readline()

--- a/src/zocalo/cli/dlq_reinject.py
+++ b/src/zocalo/cli/dlq_reinject.py
@@ -69,7 +69,10 @@ def run() -> None:
     transport = workflows.transport.lookup(args.transport)()
 
     stdin = []
-    stdin_fileno = getattr(sys.stdin, "fileno", lambda: None)()
+    try:
+        stdin_fileno = getattr(sys.stdin, "fileno", lambda: None)()
+    except Exception:
+        stdin_fileno = None
     if isinstance(stdin_fileno, int) and select.select([sys.stdin], [], [], 0.0)[0]:
         dlq_purge_filename_format = re.compile(r"^  \/")
         while True:

--- a/src/zocalo/cli/dlq_reinject.py
+++ b/src/zocalo/cli/dlq_reinject.py
@@ -3,11 +3,13 @@
 #   Take a dead letter queue message from a file and send it back to its queue
 #   for a retry.
 #
-
+from __future__ import annotations
 
 import argparse
 import json
 import os
+import re
+import select
 import sys
 import time
 from pprint import pprint
@@ -66,14 +68,24 @@ def run() -> None:
     args = parser.parse_args()
     transport = workflows.transport.lookup(args.transport)()
 
-    if not args.files:
-        print("No DLQ message files given.")
-        sys.exit(0)
+    stdin = []
+    if select.select([sys.stdin], [], [], 0.0)[0]:
+        dlq_purge_filename_format = re.compile(r"^  \/")
+        while True:
+            line = sys.stdin.readline()
+            if not line:
+                break
+            if dlq_purge_filename_format.match(line):
+                stdin.append(line.strip())
+        print(f"{len(stdin)} filenames read from stdin")
+
+    if not stdin and not args.files:
+        sys.exit("No DLQ message files given.")
 
     transport.connect()
 
     first = True
-    for dlqfile in args.files:
+    for dlqfile in args.files + stdin:
         if not os.path.exists(dlqfile):
             print(f"Ignoring missing file {dlqfile}")
             continue

--- a/tests/cli/test_dlq_purge.py
+++ b/tests/cli/test_dlq_purge.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from datetime import datetime
 from unittest import mock
@@ -6,7 +5,7 @@ from unittest import mock
 import workflows.transport
 from workflows.transport.common_transport import CommonTransport
 
-from zocalo.cli.dlq_purge import run
+import zocalo.cli.dlq_purge as dlq_purge
 
 
 def gen_header_activemq(i):
@@ -32,8 +31,6 @@ def gen_header_rabbitmq(i, use_datetime=True):
 
 
 def test_dlq_purge_activemq(mocker, tmp_path):
-    os.chdir(tmp_path)
-
     def mock_subscribe(source, receive_message, acknowledgement):
         for i in range(10):
             header = gen_header_activemq(i)
@@ -46,22 +43,20 @@ def test_dlq_purge_activemq(mocker, tmp_path):
     mocker.patch.object(workflows.transport, "lookup", return_value=mocked_transport)
     mocked_transport().subscribe = mock_subscribe
 
-    testargs = ["prog", "garbage.per_image_analysis"]
+    testargs = ["prog", "--location", str(tmp_path), "garbage.per_image_analysis"]
     with mock.patch.object(sys, "argv", testargs):
-        run()
+        dlq_purge.run()
 
     mocked_transport().ack.assert_has_calls(
         [mock.call(gen_header_activemq(i)) for i in range(10)]
     )
 
-    dlq_dirs = list(tmp_path.glob("DLQ/*"))
+    dlq_dirs = list(tmp_path.iterdir())
     assert len(dlq_dirs) == 1
     assert len(list(dlq_dirs[0].glob("**/*"))) == 10
 
 
 def test_dlq_purge_rabbitmq(mocker, tmp_path):
-    os.chdir(tmp_path)
-
     def mock_subscribe(source, receive_message, acknowledgement):
         for i in range(10):
             header = gen_header_rabbitmq(i)
@@ -74,9 +69,16 @@ def test_dlq_purge_rabbitmq(mocker, tmp_path):
     mocker.patch.object(workflows.transport, "lookup", return_value=mocked_transport)
     mocked_transport().subscribe = mock_subscribe
 
-    testargs = ["prog", "--transport", "PikaTransport", "garbage.per_image_analysis"]
+    testargs = [
+        "prog",
+        "--location",
+        str(tmp_path),
+        "--transport",
+        "PikaTransport",
+        "garbage.per_image_analysis",
+    ]
     with mock.patch.object(sys, "argv", testargs):
-        run()
+        dlq_purge.run()
 
     mocked_transport().ack.assert_has_calls(
         [
@@ -87,6 +89,6 @@ def test_dlq_purge_rabbitmq(mocker, tmp_path):
         ]
     )
 
-    dlq_dirs = list(tmp_path.glob("DLQ/*"))
+    dlq_dirs = list(tmp_path.iterdir())
     assert len(dlq_dirs) == 1
     assert len(list(dlq_dirs[0].glob("**/*"))) == 10


### PR DESCRIPTION
* ``zocalo.dlq_purge`` offers a ``--location`` flag to override where files are being written
* ``zocalo.dlq_reinject`` can again understand ``zocalo.dlq_purge`` output passed on stdin
* Tests now pass when running in an environment with `ZOCALO_CONFIG` and a DLQ dumping location set
* purge output was wrong, needed two leading spaces for filenames
* remove leftover print from purge command
* some pathlib/fstring updates