### PR TITLE
Add 'dlq-reinjected' header to reinjected messages

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased
 ----------
+* Reinjected messages now carry a ``dlq-reinjected: True`` header field
 
 0.13.0 (2021-12-01)
 -------------------

--- a/src/zocalo/cli/dlq_reinject.py
+++ b/src/zocalo/cli/dlq_reinject.py
@@ -122,12 +122,15 @@ def run() -> None:
             ):
                 if drop_field in header:
                     del header[drop_field]
+            header["dlq-reinjected"] = "True"
             send_function(
                 destination[2], dlqmsg["message"], headers=header, ignore_namespace=True
             )
         elif args.transport == "PikaTransport":
             print("pika transport detected")
             header = dlqmsg["header"]
+            header["dlq-reinjected"] = "True"
+            header = _rabbit_prepare_header(header)
             exchange = header.get("headers", {}).get("x-death", {})[0].get("exchange")
             if exchange:
                 rmqapi = RabbitMQAPI.from_zocalo_configuration(zc)
@@ -135,7 +138,6 @@ def run() -> None:
                 for exch in exchange_info:
                     if exch["name"] == exchange:
                         if exch["type"] == "fanout":
-                            header = _rabbit_prepare_header(header)
                             transport.broadcast(
                                 args.destination_override or destination,
                                 dlqmsg["message"],
@@ -145,7 +147,6 @@ def run() -> None:
                 destination = (
                     header.get("headers", {}).get("x-death", {})[0].get("queue")
                 )
-                header = _rabbit_prepare_header(header)
                 transport.send(
                     args.destination_override or destination,
                     dlqmsg["message"],

--- a/src/zocalo/cli/dlq_reinject.py
+++ b/src/zocalo/cli/dlq_reinject.py
@@ -130,7 +130,6 @@ def run() -> None:
             print("pika transport detected")
             header = dlqmsg["header"]
             header["dlq-reinjected"] = "True"
-            header = _rabbit_prepare_header(header)
             exchange = header.get("headers", {}).get("x-death", {})[0].get("exchange")
             if exchange:
                 rmqapi = RabbitMQAPI.from_zocalo_configuration(zc)
@@ -141,7 +140,7 @@ def run() -> None:
                             transport.broadcast(
                                 args.destination_override or destination,
                                 dlqmsg["message"],
-                                headers=header,
+                                headers=_rabbit_prepare_header(header),
                             )
             else:
                 destination = (
@@ -150,7 +149,7 @@ def run() -> None:
                 transport.send(
                     args.destination_override or destination,
                     dlqmsg["message"],
-                    headers=header,
+                    headers=_rabbit_prepare_header(header),
                 )
         if args.remove:
             os.remove(dlqfile)

--- a/tests/cli/test_dlq_reinject.py
+++ b/tests/cli/test_dlq_reinject.py
@@ -34,12 +34,11 @@ def gen_header_rabbitmq(i, use_datetime=True):
 
 
 def test_dlq_reinject_activemq(mocker, tmp_path):
-
     mocked_transport = mocker.MagicMock(CommonTransport)
     mocker.patch.object(workflows.transport, "lookup", return_value=mocked_transport)
 
     dlq_path = tmp_path / "DLQ"
-    dlq_path.mkdir(exist_ok=True)
+    dlq_path.mkdir()
 
     for i in range(10):
         with open(dlq_path / f"msg_{i}", "w") as f:
@@ -73,12 +72,11 @@ def test_dlq_reinject_activemq(mocker, tmp_path):
 
 
 def test_dlq_reinject_rabbitmq(mocker, tmp_path):
-
     mocked_transport = mocker.MagicMock(CommonTransport)
     mocker.patch.object(workflows.transport, "lookup", return_value=mocked_transport)
 
     dlq_path = tmp_path / "DLQ"
-    dlq_path.mkdir(exist_ok=True)
+    dlq_path.mkdir()
 
     for i in range(10):
         with open(dlq_path / f"msg_{i}", "w") as f:


### PR DESCRIPTION
so that downstream services can take reinjection into account when
considering eg. timestamps and timeouts.