### PR TITLE
Add from __future__ import annotations

### DIFF
--- a/.azure-pipelines/flake8-validation.py
+++ b/.azure-pipelines/flake8-validation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 

--- a/.azure-pipelines/syntax-validation.py
+++ b/.azure-pipelines/syntax-validation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 import os
 import sys

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,32 @@
 repos:
+# Syntax validation and some basic sanity checks
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+  - id: check-merge-conflict
+  - id: check-ast
+    fail_fast: True
+  - id: check-json
+  - id: check-added-large-files
+    args: ['--maxkb=200']
+  - id: check-yaml
 
 # Automatically sort imports
 - repo: https://github.com/PyCQA/isort
   rev: 5.9.3
   hooks:
   - id: isort
+    args: [
+           '-a', 'from __future__ import annotations',        # 3.7-3.11
+           '--rm', 'from __future__ import absolute_import',  # -3.0
+           '--rm', 'from __future__ import division',         # -3.0
+           '--rm', 'from __future__ import generator_stop',   # -3.7
+           '--rm', 'from __future__ import generators',       # -2.3
+           '--rm', 'from __future__ import nested_scopes',    # -2.2
+           '--rm', 'from __future__ import print_function',   # -3.0
+           '--rm', 'from __future__ import unicode_literals', # -3.0
+           '--rm', 'from __future__ import with_statement',   # -2.6
+          ]
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black
@@ -19,17 +41,6 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: ['flake8-comprehensions==3.5.0']
-
-# Syntax validation and some basic sanity checks
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
-  hooks:
-  - id: check-merge-conflict
-  - id: check-ast
-  - id: check-json
-  - id: check-added-large-files
-    args: ['--maxkb=200']
-  - id: check-yaml
 
 # Type checking
 - repo: https://github.com/pre-commit/mirrors-mypy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from __future__ import annotations
+
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory is
 # relative to the documentation root, use os.path.abspath to make it

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 from setuptools import setup
 
 _rst_section = "\n--------"

--- a/src/zocalo/__init__.py
+++ b/src/zocalo/__init__.py
@@ -1,5 +1,7 @@
 """Top-level package for Zocalo."""
 
+from __future__ import annotations
+
 import logging
 import socket
 import warnings

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import base64
 import configparser
@@ -17,14 +19,14 @@ from zocalo.util.rabbitmq import (
     ExchangeSpec,
     PolicySpec,
     QueueSpec,
-    RabbitMQAPI,
-    UserSpec,
 )
+from zocalo.util.rabbitmq import RabbitMQAPI as _RabbitMQAPI
+from zocalo.util.rabbitmq import UserSpec
 
 logger = logging.getLogger("zocalo.cli.configure_rabbitmq")
 
 
-class RabbitMQAPI(RabbitMQAPI):
+class RabbitMQAPI(_RabbitMQAPI):
     @functools.singledispatchmethod  # type: ignore
     def create_component(self, component):
         raise NotImplementedError(f"Component {component} not recognised")

--- a/src/zocalo/cli/dlq_check.py
+++ b/src/zocalo/cli/dlq_check.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 
 import workflows.transport

--- a/src/zocalo/cli/dlq_purge.py
+++ b/src/zocalo/cli/dlq_purge.py
@@ -4,6 +4,8 @@
 #   in a temporary directory.
 #
 
+from __future__ import annotations
+
 import argparse
 import json
 import pathlib

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -3,6 +3,8 @@
 #   Process a datacollection
 #
 
+from __future__ import annotations
+
 import argparse
 import getpass
 import json

--- a/src/zocalo/cli/queue_drain.py
+++ b/src/zocalo/cli/queue_drain.py
@@ -4,6 +4,8 @@
 #
 
 
+from __future__ import annotations
+
 import argparse
 import queue
 import sys

--- a/src/zocalo/cli/shutdown.py
+++ b/src/zocalo/cli/shutdown.py
@@ -3,6 +3,8 @@
 #   Stop a zocalo service
 #
 
+from __future__ import annotations
+
 import argparse
 import socket
 import sys

--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -3,6 +3,8 @@
 #   Wraps a command so that its status can be tracked in zocalo
 #
 
+from __future__ import annotations
+
 import argparse
 import faulthandler
 import json

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import inspect
 import itertools

--- a/src/zocalo/configuration/argparse.py
+++ b/src/zocalo/configuration/argparse.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from typing import Iterable, List
 

--- a/src/zocalo/configuration/plugin_graylog.py
+++ b/src/zocalo/configuration/plugin_graylog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import socket
 

--- a/src/zocalo/configuration/plugin_jmx.py
+++ b/src/zocalo/configuration/plugin_jmx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from marshmallow import fields
 
 from zocalo.configuration import PluginSchema

--- a/src/zocalo/configuration/plugin_rabbitmqapi.py
+++ b/src/zocalo/configuration/plugin_rabbitmqapi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from marshmallow import fields
 
 from zocalo.configuration import PluginSchema

--- a/src/zocalo/configuration/plugin_storage.py
+++ b/src/zocalo/configuration/plugin_storage.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Storage:
     @staticmethod
     def activate(configuration, config_object):

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import sys
 

--- a/src/zocalo/service/schlockmeister.py
+++ b/src/zocalo/service/schlockmeister.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import uuid
 from typing import Any, Dict, Set, Tuple

--- a/src/zocalo/util/jmxstats.py
+++ b/src/zocalo/util/jmxstats.py
@@ -10,6 +10,8 @@
 #  jmx.org.apache.activemq(type="Broker", brokerName="localhost/TotalConsumerCount")
 
 
+from __future__ import annotations
+
 import base64
 import json
 import urllib.request
@@ -46,7 +48,9 @@ class JMXAPI:
             raise zocalo.ConfigurationError(
                 "There are no JMX credentials configured in your environment"
             )
-        self.url = f"http://{zc.jmx['host']}:{zc.jmx['port']}/{zc.jmx['base_url']}/read/"
+        self.url = (
+            f"http://{zc.jmx['host']}:{zc.jmx['port']}/{zc.jmx['base_url']}/read/"
+        )
         self._authstring = b"Basic " + base64.b64encode(
             zc.jmx["username"].encode("utf-8")
             + b":"

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import enum
 import logging

--- a/src/zocalo/util/symlink.py
+++ b/src/zocalo/util/symlink.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 from typing import Union
 

--- a/src/zocalo/wrapper.py
+++ b/src/zocalo/wrapper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import threading
 

--- a/tests/cli/test_dlq_check.py
+++ b/tests/cli/test_dlq_check.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import zocalo.cli.dlq_check

--- a/tests/cli/test_dlq_purge.py
+++ b/tests/cli/test_dlq_purge.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 from datetime import datetime
 from unittest import mock

--- a/tests/cli/test_dlq_reinject.py
+++ b/tests/cli/test_dlq_reinject.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import sys
 import time

--- a/tests/cli/test_go.py
+++ b/tests/cli/test_go.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 
 

--- a/tests/cli/test_queue_drain.py
+++ b/tests/cli/test_queue_drain.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import workflows.transport

--- a/tests/cli/test_shutdown.py
+++ b/tests/cli/test_shutdown.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from unittest import mock
 

--- a/tests/cli/test_wrap.py
+++ b/tests/cli/test_wrap.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 
 

--- a/tests/configuration/test_configuration.py
+++ b/tests/configuration/test_configuration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import pathlib

--- a/tests/configuration/test_plugin_graylog.py
+++ b/tests/configuration/test_plugin_graylog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/configuration/test_plugin_jmx.py
+++ b/tests/configuration/test_plugin_jmx.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 import zocalo.configuration

--- a/tests/configuration/test_plugin_storage.py
+++ b/tests/configuration/test_plugin_storage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zocalo.configuration
 
 sample_configuration = """

--- a/tests/test_graylog.py
+++ b/tests/test_graylog.py
@@ -1,6 +1,8 @@
 """Tests related to graylog functionality."""
 
 
+from __future__ import annotations
+
 from unittest import mock
 
 import pytest

--- a/tests/test_zocalo.py
+++ b/tests/test_zocalo.py
@@ -2,6 +2,8 @@
 
 """Tests for `zocalo` package."""
 
+from __future__ import annotations
+
 import pytest
 
 import zocalo

--- a/tests/util/test.py
+++ b/tests/util/test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zocalo.util
 
 

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 
 import pytest

--- a/tests/util/test_symlink.py
+++ b/tests/util/test_symlink.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import zocalo.util.symlink
 
 


### PR DESCRIPTION
and update pre-commits:
* Stop evaluation on syntax errors
  (requires pre-commit>=2.16, displays harmless warning otherwise)
* Actively manage `future` imports
* Fix one mypy complaint