### PR TITLE
Fix header parsing in `dlq_reinject` for RabbitMQ

### DIFF
--- a/src/zocalo/cli/dlq_reinject.py
+++ b/src/zocalo/cli/dlq_reinject.py
@@ -146,7 +146,7 @@ def run() -> None:
             print("pika transport detected")
             header = dlqmsg["header"]
             header["dlq-reinjected"] = "True"
-            exchange = header.get("headers", {}).get("x-death", {})[0].get("exchange")
+            exchange = header.get("x-death", [{}])[0].get("exchange")
             if exchange:
                 rmqapi = RabbitMQAPI.from_zocalo_configuration(zc)
                 exchange_info = rmqapi.get("queues").json()
@@ -159,9 +159,7 @@ def run() -> None:
                                 headers=_rabbit_prepare_header(header),
                             )
             else:
-                destination = (
-                    header.get("headers", {}).get("x-death", {})[0].get("queue")
-                )
+                destination = header.get("x-death", [{}])[0].get("queue")
                 transport.send(
                     args.destination_override or destination,
                     dlqmsg["message"],

--- a/tests/cli/test_dlq_reinject.py
+++ b/tests/cli/test_dlq_reinject.py
@@ -28,9 +28,7 @@ def gen_header_rabbitmq(i, use_datetime=True):
     if use_datetime:
         tstamp = datetime.fromtimestamp(tstamp)
     return {
-        "headers": {
-            "x-death": [{"time": tstamp, "queue": "garbage.per_image_analysis"}]
-        },
+        "x-death": [{"time": tstamp, "queue": "garbage.per_image_analysis"}],
         "message-id": f"ID:foo.bar.com-{i}",
     }
 


### PR DESCRIPTION
The format of messages from `dlq_purge` has all headers placed under the header key with no secondary headers structure which is currently assumed by `dlq_reinject`.

`PikaTransport` squashes what RabbitMQ calls `headers` and other properties that Zocalo considers to be headers into a single `header` which is what is written out by `dlq_purge`. When reinjecting the message we drop the properties not in the original RabbitMQ `headers` from the header before reinjecting so this should be fine and `dlq_reinject` should not look for a secondary `headers` structure within the header.