### PR TITLE
Be more tolerant of missing plugin files

### DIFF
--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -110,6 +110,13 @@ class Configuration:
                 f"Plugin configuration {plugin_configuration} could not be resolved, "
                 f"{e}"
             ) from None
+        except FileNotFoundError as e:
+            logger.warning(
+                f"Plugin configuration {plugin_configuration} could not be resolved, "
+                f"{e}",
+            )
+            self._plugin_configurations[plugin_configuration] = {}
+            return
         try:
             yaml_dict = yaml.safe_load(configuration)
         except yaml.MarkedYAMLError as e:
@@ -134,6 +141,8 @@ class Configuration:
             if isinstance(self._plugin_configurations[config_name], pathlib.Path):
                 self._resolve(config_name)
             configuration = self._plugin_configurations[config_name]
+            if not configuration:
+                continue
             plugin = _load_plugin(configuration["plugin"])  # type: ignore
             if plugin:
                 plugin_parameters = inspect.signature(plugin.activate).parameters


### PR DESCRIPTION
Catch FileNotFoundError and log warning instead.

A particular plugin may only be required depending on the value of other configuration parameters, so it makes no sense to stop because of an error reading something we might not actually need.