### PR TITLE
RabbitMQAPI: support comma-separated base_url

### DIFF
--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -652,7 +652,7 @@ class RabbitMQAPI:
         return success, failure
 
     def get(
-        self, endpoint: str, params: Dict[str, Any] = None, timeout: float = None
+        self, endpoint: str, params: Dict[str, Any] = None, timeout: float | None = None
     ) -> requests.Response:
         return self._session.get(
             f"{self._url}/{endpoint}", params=params, timeout=timeout
@@ -663,7 +663,7 @@ class RabbitMQAPI:
         endpoint: str,
         params: Dict[str, Any] = None,
         json: Dict[str, Any] = None,
-        timeout: float = None,
+        timeout: float | None = None,
     ) -> requests.Response:
         return self._session.put(
             f"{self._url}/{endpoint}", params=params, json=json, timeout=timeout
@@ -674,15 +674,14 @@ class RabbitMQAPI:
         endpoint: str,
         data: Optional[Dict[str, Any]] = None,
         json: Optional[Dict[str, Any]] = None,
-        timeout: float = None,
+        timeout: float | None = None,
     ) -> requests.Response:
-        print(f"POST {self._url}/{endpoint}")
         return self._session.post(
             f"{self._url}/{endpoint}", data=data, json=json, timeout=timeout
         )
 
     def delete(
-        self, endpoint: str, params: Dict[str, Any] = None, timeout: float = None
+        self, endpoint: str, params: Dict[str, Any] = None, timeout: float | None = None
     ) -> requests.Response:
         return self._session.delete(
             f"{self._url}/{endpoint}", params=params, timeout=timeout

--- a/tests/cli/test_dlq_check.py
+++ b/tests/cli/test_dlq_check.py
@@ -47,6 +47,7 @@ def test_activemq_dlq_rabbitmq_check(requests_mock):
             },
         ],
     )
+    requests_mock.get("/api/health/checks/alarms", json={"status": "ok"})
 
     checked = zocalo.cli.dlq_check.check_dlq_rabbitmq(zc, "zocalo")
     assert checked == {"dlq.images": 2, "dlq.transient": 5}

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -20,8 +20,11 @@ def zocalo_configuration(mocker):
 
 
 @pytest.fixture
-def rmqapi(zocalo_configuration):
-    return rabbitmq.RabbitMQAPI.from_zocalo_configuration(zocalo_configuration)
+def rmqapi(requests_mock, zocalo_configuration):
+    requests_mock.get(re.compile("/health/checks/alarms"), json={"status": "ok"})
+    api = rabbitmq.RabbitMQAPI.from_zocalo_configuration(zocalo_configuration)
+    requests_mock.reset_mock()
+    return api
 
 
 def test_http_api_request(zocalo_configuration):


### PR DESCRIPTION
This allows for failover for clustered nodes if one node is out of action.

Iteratively attempts to `GET` the `/health/checks/alarms` for each url contained in the comma-separated `base_url` field, returning an instance as soon as it can connect without a `ConnectionError`.

* Setup a session for all requests
* Add timeout parameters to get/post/put/delete.

A comma-separated `base_url` can be set via the `RabbitAPI` configuration plugin, e.g.:
```
plugin: rabbitmqapi

base_url: http://rabbitmq1.example.com:15672/api,http://rabbitmq2.example.com:15672/api,http://rabbitmq3.example.com:15672/api
username: admin
password: password
vhost: zocalo
```

A slightly more intrusive change would be to make the `RabbitAPI` configuration plugin to be more similar to the `Pika` configuration plugin, i.e.:

```
plugin: rabbitmqapi
host: rabbitmq1.example.com,rabbitmq2.example.com,rabbitmq3.example.com
port: 15672
username: admin
password: password
vhost: zocalo
```