### PR TITLE
Add a logging plugin

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ History
 Unreleased
 ----------
 
+0.18.0 (2022-04-08)
+-------------------
+* Added a logging configuration plugin to comprehensively
+  configure logging across applications.
+
 0.17.0 (2022-03-03)
 -------------------
 * ``zocalo.configure_rabbitmq`` cli:

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -122,6 +122,9 @@ configuration. While it is fundamentally possible to combine multiple
 configurations (using the ``incremental`` key), this will cause all sorts of
 problems and is therefore strongly discouraged.
 
+Please note that Zocalo commands will currently always add a handler to log
+to the console. This behaviour may be reviewed in the future.
+
 The Zocalo configuration object exposes a facility to read out and increase
 a verbosity level, which will apply incremental changes to the logging
 configuration. In the above example setting ``zc.logging.verbosity = 1``

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -147,14 +147,31 @@ To use these handlers you can declare them as follows:
 
    some-unique-name:
        plugin: logging
-        handlers:
-          graylog:
-            (): zocalo.configuration.plugin_logging.GraylogUDPHandler
-            host: example.com
-            port: 1234
-        root:
-          handlers: [ graylog ]
+       handlers:
+         graylog:
+           (): zocalo.configuration.plugin_logging.GraylogUDPHandler
+           host: example.com
+           port: 1234
+       root:
+         handlers: [ graylog ]
 
+The logging plugin offers a log filter (``DowngradeFilter``), which can
+be attached to loggers to reduce the severity of messages. It takes two
+parameters, ``reduce_to`` (default: ``WARNING``) and ``only_below``
+(default: ``CRITICAL``), and messages with a level between ``reduce_to``
+and ``only_below`` have their log level changed to ``reduce_to``:
+
+.. code-block:: yaml
+
+   some-unique-name:
+       plugin: logging
+       filters:
+         downgrade_all_warnings_and_errors:
+           (): zocalo.configuration.plugin_logging.DowngradeFilter
+           reduce_to: INFO
+       loggers:
+         pika:
+           filters: [ downgrade_all_warnings_and_errors ]
 
 Graylog plugin
 ^^^^^^^^^^^^^^

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -87,10 +87,67 @@ Storage plugin
 
 tbd.
 
+Logging plugin
+^^^^^^^^^^^^^^
+
+This plugin allows site-wide logging configuration. For example:
+
+.. code-block:: yaml
+
+   some-unique-name:
+       plugin: logging
+       loggers:
+         zocalo: WARNING
+         workflows: WARNING
+       verbose:
+         - loggers:
+             zocalo: INFO
+         - loggers:
+             zocalo: DEBUG
+             workflows: DEBUG
+
+would set the Python loggers ``zocalo`` and ``workflows`` to only report
+messages of level ``WARNING`` and above. Apart from the additional
+``plugin:``- and ``verbose:``-keys the syntax follows the
+`Python Logging Configuration Schema`_. This allows not only the setting of
+log levels, but also the definition of log handlers, filters, and formatters.
+
+The Zocalo configuration object exposes a facility to read out and increase
+a verbosity level, which will apply incremental changes to the logging
+configuration. In the above example setting ``zc.logging.verbosity = 1``
+would change the log level for ``zocalo`` to ``INFO`` while leaving
+``workflows`` at ``WARNING``. Setting ``zc.logging.verbosity = 2`` would
+change both to ``DEBUG``.
+
+Note that the verbosity level cannot be decreased, and due to the Python
+Logging model verbosity changes should be done close to the initial logging
+setup, as otherwise child loggers may have been set up inheriting previous
+settings.
+
+The logging plugin offers two Graylog handlers (``GraylogUDPHandler``,
+``GraylogTCPHandler``). These are based on `graypy`_, but offer slightly
+improved performance by front-loading DNS lookups and apply a patch to
+``graypy`` to ensure syslog levels are correctly reported to Graylog.
+To use these handlers you can declare them as follows:
+
+.. code-block:: yaml
+
+   some-unique-name:
+       plugin: logging
+        handlers:
+          graylog:
+            (): zocalo.configuration.plugin_logging.GraylogUDPHandler
+            host: example.com
+            port: 1234
+        root:
+          handlers: [ graylog ]
+
+
 Graylog plugin
 ^^^^^^^^^^^^^^
 
-tbd.
+This should be considered deprecated and will be removed at some point in the
+future. Use the Logging plugin instead.
 
 .. _environments:
 
@@ -158,8 +215,10 @@ Writing your own plugins
 
 tbd.
 
-.. _example configuration file: https://github.com/DiamondLightSource/python-zocalo/blob/main/contrib/site-configuration.yml
-.. _workflows: https://github.com/DiamondLightSource/python-workflows/tree/main/src/workflows/util/zocalo
-.. _YAML: https://en.wikipedia.org/wiki/YAML
-.. _YAML primer: https://getopentest.org/reference/yaml-primer.html
+.. _Python Logging Configuration Schema: https://docs.python.org/3/library/logging.config.html#dictionary-schema-details
 .. _Python entry points: https://amir.rachum.com/blog/2017/07/28/python-entry-points/
+.. _YAML primer: https://getopentest.org/reference/yaml-primer.html
+.. _YAML: https://en.wikipedia.org/wiki/YAML
+.. _example configuration file: https://github.com/DiamondLightSource/python-zocalo/blob/main/contrib/site-configuration.yml
+.. _graypy: https://pypi.org/project/graypy/
+.. _workflows: https://github.com/DiamondLightSource/python-workflows/tree/main/src/workflows/util/zocalo

--- a/docs/siteconfig.rst
+++ b/docs/siteconfig.rst
@@ -97,20 +97,30 @@ This plugin allows site-wide logging configuration. For example:
    some-unique-name:
        plugin: logging
        loggers:
-         zocalo: WARNING
-         workflows: WARNING
+         zocalo:
+           level: WARNING
+         workflows:
+           level: WARNING
        verbose:
          - loggers:
-             zocalo: INFO
+             zocalo:
+               level: INFO
          - loggers:
-             zocalo: DEBUG
-             workflows: DEBUG
+             zocalo:
+               level: DEBUG
+             workflows:
+               level: DEBUG
 
 would set the Python loggers ``zocalo`` and ``workflows`` to only report
 messages of level ``WARNING`` and above. Apart from the additional
 ``plugin:``- and ``verbose:``-keys the syntax follows the
 `Python Logging Configuration Schema`_. This allows not only the setting of
 log levels, but also the definition of log handlers, filters, and formatters.
+
+A plugin definition will, by default, overwrite any previous logging
+configuration. While it is fundamentally possible to combine multiple
+configurations (using the ``incremental`` key), this will cause all sorts of
+problems and is therefore strongly discouraged.
 
 The Zocalo configuration object exposes a facility to read out and increase
 a verbosity level, which will apply incremental changes to the logging

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,10 +67,11 @@ workflows.services =
     Mailer = zocalo.service.mailer:Mailer
 zocalo.configuration.plugins =
     graylog = zocalo.configuration.plugin_graylog:Graylog
+    jmx = zocalo.configuration.plugin_jmx:JMX
+    logging = zocalo.configuration.plugin_logging:Logging
     rabbitmqapi = zocalo.configuration.plugin_rabbitmqapi:RabbitAPI
     smtp = zocalo.configuration.plugin_smtp:SMTP
     storage = zocalo.configuration.plugin_storage:Storage
-    jmx = zocalo.configuration.plugin_jmx:JMX
 zocalo.wrappers =
     dummy = zocalo.wrapper:DummyWrapper
 

--- a/src/zocalo/configuration/plugin_graylog.py
+++ b/src/zocalo/configuration/plugin_graylog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import socket
+import warnings
 
 import graypy.handler
 from marshmallow import fields, validate
@@ -45,6 +46,12 @@ class Graylog:
 
     @staticmethod
     def activate(configuration):
+        warnings.warn(
+            "The Graylog configuration plugin will soon be deprecated."
+            " It will be replaced by the more powerful logging plugin.",
+            PendingDeprecationWarning,
+        )
+
         graypy.handler.SYSLOG_LEVELS = _PythonLevelToSyslogConverter()
 
         # Create and enable graylog handler

--- a/src/zocalo/configuration/plugin_logging.py
+++ b/src/zocalo/configuration/plugin_logging.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import copy
+import logging
+import logging.config
+import socket
+from pprint import pprint
+from typing import Any
+
+import graypy.handler
+import logging_tree
+
+
+def _config_is_incremental(config: dict[str, Any]) -> bool:
+    forbidden_keys = {"filters", "formatters", "handlers"}
+
+    # Incremental configurations must not declare any of those
+    if any(key in config for key in forbidden_keys):
+        return False
+
+    # Incremental configurations must not attach any of those
+    # to the root logger
+    if any(key in config.get("root", {}) for key in forbidden_keys):
+        return False
+    # or any other logger
+    for logger in config.get("loggers", {}).values():
+        if any(key in logger for key in forbidden_keys):
+            return False
+
+    return True
+
+
+class LoggingIncrementer:
+    def __init__(self, setup: dict[str, Any]):
+        self._setup = setup
+        self._verbosity_level = 0
+
+    @property
+    def verbosity(self) -> int:
+        return self._verbosity_level
+
+    @verbosity.setter
+    def verbosity(self, value: int) -> None:
+        if value <= self._verbosity_level:
+            return
+        for verbosity_level in range(self._verbosity_level, value):
+            try:
+                incremental = self._setup.get("verbose", [])[verbosity_level]
+            except IndexError:
+                break
+            print(f"== Applying verbosity {verbosity_level+1} ==")
+            incremental.setdefault("version", self._setup["version"])
+            incremental.setdefault("incremental", True)
+            pprint(incremental)
+            logging.config.dictConfig(incremental)
+            self._verbosity_level = value
+            logging_tree.printout()
+
+    def __repr__(self) -> str:
+        return f"<LoggingConfiguration verbosity={self._verbosity_level}>"
+
+
+class Logging:
+    """
+    A plugin to set up consistent logging configuration
+    using a Zocalo configuration file.
+    """
+
+    @staticmethod
+    def activate(configuration, config_object):
+        logconfig = copy.deepcopy(configuration)
+
+        pprint(logconfig)
+        del logconfig["plugin"]
+        logconfig.setdefault("version", 1)
+        logconfig.setdefault("disable_existing_loggers", False)
+        logconfig.setdefault("incremental", False)
+        pprint(logconfig)
+        logging.config.dictConfig(logconfig)
+        logging_tree.printout()
+
+        if logconfig["incremental"] and not _config_is_incremental(logconfig):
+            raise ValueError(
+                "Logging configuration error: definition defines items not allowed "
+                "in an incremental definition"
+            )
+
+        for level, verbosity_def in enumerate(logconfig.get("verbose", [])):
+            if not isinstance(verbosity_def, dict):
+                raise ValueError(
+                    f"Logging configuration error: verbosity level {level+1} definition "
+                    "is not a dictionary"
+                )
+            verbosity_def.setdefault("version", logconfig["version"])
+            verbosity_def.setdefault("incremental", True)
+            if verbosity_def["incremental"] and not _config_is_incremental(
+                verbosity_def
+            ):
+                raise ValueError(
+                    f"Logging configuration error: verbosity level {level+1} definition "
+                    "defines items not allowed in an incremental definition"
+                )
+
+        return LoggingIncrementer(logconfig)
+
+
+def _monkeypatch_graypy() -> None:
+    """
+    Monkeypatch a helper class into graypy to support log levels in Graylog.
+    This translates Python integer level numbers to syslog levels.
+    """
+
+    class PythonLevelToSyslogConverter:
+        @staticmethod
+        def get(level, _):
+            if level < 20:
+                return 7  # DEBUG
+            elif level < 25:
+                return 6  # INFO
+            elif level < 30:
+                return 5  # NOTICE
+            elif level < 40:
+                return 4  # WARNING
+            elif level < 50:
+                return 3  # ERROR
+            elif level < 60:
+                return 2  # CRITICAL
+            else:
+                return 1  # ALERT
+
+    graypy.handler.SYSLOG_LEVELS = PythonLevelToSyslogConverter()
+
+
+def _resolve_hostname(host: str) -> str:
+    # Attempt to resolve the hostname only once during setup
+    # rather than once for each connection, which is the default behaviour.
+    # For a UDP handler the default would mean one lookup per logging call.
+    try:
+        return socket.gethostbyname(host)
+    except Exception:
+        return host
+
+
+def GraylogTCPHandler(*, host: str, port: int) -> logging.Handler:
+    """
+    A handler factory to enable logging to a Graylog server using graypy via TCP.
+    """
+    _monkeypatch_graypy()
+    return graypy.GELFTCPHandler(_resolve_hostname(host), port, level_names=True)
+
+
+def GraylogUDPHandler(*, host: str, port: int) -> logging.Handler:
+    """
+    A handler factory to enable logging to a Graylog server using graypy via UDP.
+    """
+    _monkeypatch_graypy()
+    return graypy.GELFUDPHandler(_resolve_hostname(host), port, level_names=True)

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -41,9 +41,9 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
             logging.getLogger().setLevel(logging.WARN)
             logging.getLogger("workflows").setLevel(logging.INFO)
             logging.getLogger("zocalo").setLevel(logging.DEBUG)
+            logging.getLogger("zocalo.service").setLevel(logging.DEBUG)
 
         self.log = logging.getLogger("zocalo.service")
-        self.log.setLevel(logging.DEBUG)
 
     def __init__(self):
         # load configuration and initialize logging
@@ -104,6 +104,8 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
     def on_parsing(self, options, args):
         if options.verbose:
             self.console.setLevel(logging.DEBUG)
+            if self._zc.logging:
+                self._zc.logging.verbosity = options.verbose
         if options.debug:
             self.console.setLevel(logging.DEBUG)
             if not self._zc.logging:

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -26,10 +26,8 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
         """Initialize common logging framework. Everything is logged to central
         graylog server. Depending on setting messages of DEBUG or INFO and higher
         go to console."""
-        logger = logging.getLogger()
-        logger.setLevel(logging.WARN)
 
-        # Enable logging to console
+        # Always enable logging to console
         try:
             from dlstbx.util.colorstreamhandler import ColorStreamHandler
 
@@ -37,10 +35,12 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
         except ImportError:
             self.console = logging.StreamHandler()
         self.console.setLevel(logging.INFO)
-        logger.addHandler(self.console)
+        logging.getLogger().addHandler(self.console)
 
-        logging.getLogger("workflows").setLevel(logging.INFO)
-        logging.getLogger("zocalo").setLevel(logging.DEBUG)
+        if not self._zc.logging:
+            logging.getLogger().setLevel(logging.WARN)
+            logging.getLogger("workflows").setLevel(logging.INFO)
+            logging.getLogger("zocalo").setLevel(logging.DEBUG)
 
         self.log = logging.getLogger("zocalo.service")
         self.log.setLevel(logging.DEBUG)
@@ -71,10 +71,9 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
         parser.add_option(
             "-v",
             "--verbose",
-            action="store_true",
-            dest="verbose",
-            default=False,
-            help="Show debug output",
+            action="count",
+            default=0,
+            help="Increase output verbosity",
         )
         parser.add_option(
             "--tag",
@@ -107,9 +106,10 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
             self.console.setLevel(logging.DEBUG)
         if options.debug:
             self.console.setLevel(logging.DEBUG)
-            logging.getLogger("pika").setLevel(logging.INFO)
-            logging.getLogger("stomp.py").setLevel(logging.DEBUG)
-            logging.getLogger("workflows").setLevel(logging.DEBUG)
+            if not self._zc.logging:
+                logging.getLogger("pika").setLevel(logging.INFO)
+                logging.getLogger("stomp.py").setLevel(logging.DEBUG)
+                logging.getLogger("workflows").setLevel(logging.DEBUG)
         self.options = options
 
     def before_frontend_construction(self, kwargs):

--- a/tests/configuration/test_plugin_logging.py
+++ b/tests/configuration/test_plugin_logging.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+import zocalo.configuration
+import zocalo.configuration.plugin_logging
+
+sample_configuration = """
+version: 1
+
+logsetup:
+  plugin: logging
+
+  handlers:
+    graylog:
+      (): zocalo.configuration.plugin_logging.GraylogUDPHandler
+      host: example.com
+      port: 1234
+
+  root:
+    level: WARNING
+    handlers: [ graylog ]
+
+  loggers:
+    zocalo:
+      level: INFO
+    dials:
+      level: INFO
+    pika:
+      level: WARNING
+
+  verbose:
+    - loggers:
+        dials:
+          level: DEBUG
+        pika:
+          level: INFO
+
+    - loggers:
+        pika:
+          level: DEBUG
+
+environments:
+  live:
+    - logsetup
+"""
+
+
+@mock.patch("zocalo.configuration.plugin_logging.logging")
+def test_plugin_sets_up_logging_with_variable_verbosity(logging):
+    zc = zocalo.configuration.from_string(sample_configuration)
+    logging.config.dictConfig.assert_not_called()
+    assert zc.logging is None
+
+    zc.activate_environment("live")
+    logging.config.dictConfig.assert_called_once_with(
+        {
+            "disable_existing_loggers": False,
+            "handlers": {
+                "graylog": {
+                    "()": "zocalo.configuration.plugin_logging.GraylogUDPHandler",
+                    "host": "example.com",
+                    "port": 1234,
+                }
+            },
+            "incremental": False,
+            "loggers": {
+                "dials": {"level": "INFO"},
+                "pika": {"level": "WARNING"},
+                "zocalo": {"level": "INFO"},
+            },
+            "root": {"handlers": ["graylog"], "level": "WARNING"},
+            "verbose": mock.ANY,
+            "version": 1,
+        }
+    )
+    assert zc.logging.verbosity == 0
+
+    logging.config.reset_mock()
+    logging.config.dictConfig.assert_not_called()
+
+    zc.logging.verbosity = 1
+
+    logging.config.dictConfig.assert_called_once_with(
+        {
+            "incremental": True,
+            "loggers": {"dials": {"level": "DEBUG"}, "pika": {"level": "INFO"}},
+            "version": 1,
+        }
+    )
+    assert zc.logging.verbosity == 1
+
+    logging.config.reset_mock()
+    logging.config.dictConfig.assert_not_called()
+
+    # Verbosity can't be reduced
+    zc.logging.verbosity = 0
+    assert zc.logging.verbosity == 1
+    logging.config.dictConfig.assert_not_called()
+
+    zc.logging.verbosity = 1
+    assert zc.logging.verbosity == 1
+    logging.config.dictConfig.assert_not_called()
+
+    # Verbosity can't be increased beyond maximum
+    zc.logging.verbosity = 7
+    logging.config.dictConfig.assert_called_once_with(
+        {"incremental": True, "loggers": {"pika": {"level": "DEBUG"}}, "version": 1}
+    )
+    assert zc.logging.verbosity == 2
+
+
+@pytest.mark.parametrize("protocol", ("UDP", "TCP"))
+@mock.patch("zocalo.configuration.plugin_logging.graypy")
+@mock.patch("zocalo.configuration.plugin_logging.graypy.handler")
+@mock.patch("zocalo.configuration.plugin_logging.socket")
+def test_graypy_handlers_are_set_up_correctly(socket, handler, graypy, protocol):
+    graypy_handler = getattr(graypy, f"GELF{protocol}Handler")
+    zocalo_handler = getattr(
+        zocalo.configuration.plugin_logging, f"Graylog{protocol}Handler"
+    )
+
+    graypy_handler.assert_not_called()
+    socket.gethostbyname.assert_not_called()
+
+    h = zocalo_handler(host=mock.sentinel.host, port=mock.sentinel.port)
+
+    socket.gethostbyname.assert_called_once_with(mock.sentinel.host)
+    graypy_handler.assert_called_once_with(
+        socket.gethostbyname.return_value, mock.sentinel.port, level_names=True
+    )
+    assert h == graypy_handler.return_value
+
+
+@mock.patch("zocalo.configuration.plugin_logging.logging")
+def test_incremental_configuration_with_handler_definition_is_rejected(logging):
+    zc = zocalo.configuration.from_string(
+        """
+version: 1
+
+logsetup:
+  plugin: logging
+
+  handlers:
+    graylog:
+      (): zocalo.configuration.plugin_logging.GraylogUDPHandler
+      host: example.com
+      port: 1234
+
+  incremental: True
+
+  root:
+    level: WARNING
+    handlers: [ graylog ]
+
+environments:
+  live:
+    - logsetup
+"""
+    )
+    with pytest.raises(zocalo.ConfigurationError, match="incremental"):
+        zc.activate_environment("live")
+
+
+@mock.patch("zocalo.configuration.plugin_logging.logging")
+def test_configuration_with_incremental_verbosity_definition_and_handler_is_rejected(
+    logging,
+):
+    zc = zocalo.configuration.from_string(
+        """
+version: 1
+
+logsetup:
+  plugin: logging
+
+  handlers:
+    graylog:
+      (): zocalo.configuration.plugin_logging.GraylogUDPHandler
+      host: example.com
+      port: 1234
+
+  verbose:
+    - root:
+        level: WARNING
+        handlers: [ graylog ]
+
+environments:
+  live:
+    - logsetup
+"""
+    )
+    with pytest.raises(zocalo.ConfigurationError, match="verbosity.*incremental"):
+        zc.activate_environment("live")
+
+
+@mock.patch("zocalo.configuration.plugin_logging.logging")
+def test_configuration_with_invalid_verbosity_definitions_is_rejected(logging):
+    zc = zocalo.configuration.from_string(
+        """
+version: 1
+
+logsetup:
+  plugin: logging
+
+  verbose:
+    - DEBUG
+
+environments:
+  live:
+    - logsetup
+"""
+    )
+    with pytest.raises(zocalo.ConfigurationError, match="not a dictionary"):
+        zc.activate_environment("live")


### PR DESCRIPTION
This plugin allows site-wide logging configuration.

That way `zocalo.wrap`, `zocalo.service`, `dlstbx.wrap`, `dlstbx.service`, etc. can all use the same setup