### PR TITLE
Advanced binding configuration

### DIFF
--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -38,7 +38,6 @@ class RabbitMQAPI(_RabbitMQAPI):
             source=binding.source,
             destination=binding.destination,
             destination_type=binding.destination_type.value,
-            properties_key=binding.properties_key,
         )
 
     @create_component.register  # type: ignore
@@ -107,12 +106,10 @@ def get_binding_specs(group: Dict) -> List[BindingSpec]:
             source = binding_group
             destinations = group["names"]
             routing_keys = group["names"]
-            properties_keys = group["names"]
         else:
             source = binding_group["source"]
             destinations = [binding_group["destination"]]
             routing_keys = [binding_group.get("routing_key", destinations[0])]
-            properties_keys = [binding_group["destination"]]
 
         binding_specs.extend(
             [
@@ -123,9 +120,8 @@ def get_binding_specs(group: Dict) -> List[BindingSpec]:
                     destination_type="q",
                     routing_key=rk,
                     arguments={},
-                    properties_key=pk,
                 )
-                for dest, rk, pk in zip(destinations, routing_keys, properties_keys)
+                for dest, rk in zip(destinations, routing_keys)
             ]
         )
     return binding_specs

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -111,7 +111,7 @@ def get_binding_specs(group: Dict) -> List[BindingSpec]:
         else:
             source = binding_group["source"]
             destinations = [binding_group["destination"]]
-            routing_keys = [binding_group["routing_key"]]
+            routing_keys = [binding_group.get("routing_key", destinations[0])]
             properties_keys = [binding_group["destination"]]
 
         binding_specs.extend(

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -315,14 +315,13 @@ class BindingSpec(BaseModel):
     arguments: Optional[dict] = Field(
         default_factory=dict, description="Binding arguments"
     )
+
+
+class BindingInfo(BindingSpec):
     properties_key: str = Field(
         "",
         description="Unique identifier composed of the bindings routing key and a hash of its arguments",
     )
-
-
-class BindingInfo(BindingSpec):
-    pass
 
 
 class ExchangeType(enum.Enum):

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -312,7 +312,9 @@ class BindingSpec(BaseModel):
         ..., description="Virtual host name with non-ASCII characters escaped as in C."
     )
     routing_key: str = Field("", description="Routing key attached to binding")
-    arguments: Optional[dict] = Field(None, description="Binding arguments")
+    arguments: Optional[dict] = Field(
+        default_factory=dict, description="Binding arguments"
+    )
     properties_key: str = Field(
         "",
         description="Unique identifier composed of the bindings routing key and a hash of its arguments",
@@ -348,7 +350,9 @@ class ExchangeSpec(BaseModel):
         False,
         description="Whether the exchange is internal, i.e. cannot be directly published to by a client.",
     )
-    arguments: Optional[Dict[str, Any]] = Field(None, description="Exchange arguments.")
+    arguments: Optional[Dict[str, Any]] = Field(
+        default_factory=dict, description="Exchange arguments."
+    )
     vhost: str = Field(
         ..., description="Virtual host name with non-ASCII characters escaped as in C."
     )
@@ -431,7 +435,9 @@ class QueueSpec(BaseModel):
         False,
         description="Whether the queue will be deleted automatically when no longer used.",
     )
-    arguments: Optional[Dict[str, Any]] = Field(None, description="Queue arguments.")
+    arguments: Optional[Dict[str, Any]] = Field(
+        default_factory=dict, description="Queue arguments."
+    )
     vhost: str = Field(
         ..., description="Virtual host name with non-ASCII characters escaped as in C."
     )

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -720,13 +720,17 @@ class RabbitMQAPI:
 
     def binding_declare(self, binding: BindingSpec):
         endpoint = f"bindings/{binding.vhost}/e/{binding.source}/{binding.destination_type.value}/{binding.destination}"
-        self.post(
+        resp = self.post(
             endpoint,
             json=binding.dict(
                 exclude_defaults=True,
                 exclude={"vhost", "source", "destination", "destination_type"},
             ),
         )
+        if resp.status_code == 404:
+            logger.error(f"404 not found when declaring {endpoint}")
+        elif resp.status_code == 405:
+            logger.error(f"405 not allowed to declare {endpoint}")
 
     def bindings_delete(
         self,
@@ -806,7 +810,11 @@ class RabbitMQAPI:
 
     def exchange_delete(self, vhost: str, name: str, if_unused: bool = False):
         endpoint = f"exchanges/{vhost}/{name}"
-        self.delete(endpoint, params={"if_unused": if_unused})
+        resp = self.delete(endpoint, params={"if-unused": if_unused})
+        if resp.status_code == 404:
+            logger.error(f"404 not found when deleting {endpoint}")
+        elif resp.status_code == 405:
+            logger.error(f"405 not allowed to delete {endpoint}")
 
     def policies(self, vhost: Optional[str] = None) -> List[PolicySpec]:
         endpoint = "policies"
@@ -858,7 +866,7 @@ class RabbitMQAPI:
         self, vhost: str, name: str, if_unused: bool = False, if_empty: bool = False
     ):
         endpoint = f"queues/{vhost}/{name}"
-        self.delete(endpoint, params={"if_unused": if_unused, "if_empty": if_empty})
+        self.delete(endpoint, params={"if-unused": if_unused, "if-empty": if_empty})
 
     def users(self) -> List[UserSpec]:
         endpoint = "users"

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -130,7 +130,7 @@ def test_api_queue_delete(requests_mock, rmqapi, queue_spec):
     assert requests_mock.call_count == 1
     history = requests_mock.request_history[0]
     assert history.method == "DELETE"
-    assert history.url.endswith("/api/queues/zocalo/foo?if_unused=True&if_empty=True")
+    assert history.url.endswith("/api/queues/zocalo/foo?if-unused=True&if-empty=True")
 
 
 def test_api_bindings(requests_mock, rmqapi):
@@ -163,15 +163,12 @@ def test_api_bindings(requests_mock, rmqapi):
         f"/api/bindings/zocalo/e/{binding['source']}/q/{binding['destination']}",
         json=[response],
     )
-    assert (
-        rmqapi.bindings(
-            vhost="zocalo",
-            source=binding["source"],
-            destination=binding["destination"],
-            destination_type="q",
-        )
-        == [rabbitmq.BindingInfo(**binding)]
-    )
+    assert rmqapi.bindings(
+        vhost="zocalo",
+        source=binding["source"],
+        destination=binding["destination"],
+        destination_type="q",
+    ) == [rabbitmq.BindingInfo(**binding)]
 
 
 @pytest.fixture
@@ -317,6 +314,7 @@ def test_api_exchange_declare(name, requests_mock, rmqapi):
         "type": "fanout",
         "auto_delete": True,
         "durable": True,
+        "arguments": {},
     }
 
 
@@ -326,7 +324,7 @@ def test_api_exchange_delete(requests_mock, rmqapi):
     assert requests_mock.call_count == 1
     history = requests_mock.request_history[0]
     assert history.method == "DELETE"
-    assert history.url.endswith("/api/exchanges/zocalo/foo?if_unused=True")
+    assert history.url.endswith("/api/exchanges/zocalo/foo?if-unused=True")
 
 
 def test_api_connections(requests_mock, rmqapi):


### PR DESCRIPTION
This enables more advanced routing topologies using non-default exchanges and where the routing key != queue name

E.g.:
```
exchanges:
- name: breakfast
  vhost: zocalo
  type: topic

- names:
  - ham.spam
  - ham.eggs
  - ham
  settings:
    queues:
      type: quorum
  bindings:
  - source: breakfast
    destination: ham.spam
  - source: results
    destination: ham.eggs
  - source: breakfast
    destination: ham
    routing_key: ham.*
  vhost: zocalo
```

Use `default_factory=dict` since input of `arguments=None` gets returns as `arguments={}` from the API this means that that repeated runs of the configure_rabbitmq cli don't repeatedly delete/create items

Remove `properties_key` from `BindingSpec` since you can't explicitly set this field

Correct `if_unused` and `if_empty` -> `if-unused` and `if-empty` in exchange/queue API calls