### PR TITLE
Require explicit dead-letter-routing-key-pattern

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,9 @@ History
 
 Unreleased
 ----------
+* ``zocalo.configure_rabbitmq`` cli: require explicit
+  `dead-letter-routing-key-pattern` when requesting
+  creation of a DLQ for a given queue.
 
 0.19.0 (2022-05-24)
 -------------------

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -169,7 +169,7 @@ def get_queue_specs(group: Dict) -> List[QueueSpec]:
         qspecs.extend(
             [
                 QueueSpec(
-                    name=f"dlq.{name}",
+                    name=dlq_pattern.format(name=name),
                     vhost=vhost,
                     arguments={
                         "x-queue-type": qtype,


### PR DESCRIPTION
Making dlq explicit rather than implicit means that we can choose not to have a dlq for a specific queue.

To achieve the previous functionality (i.e. queue "foo" is given
a DLQ "dlq.foo" add e.g. the following:

```
- names:
  - foo
  - bar
  settings:
    queues:
      type: quorum
      dead-letter-routing-key-pattern: dlq.{name}
```