### PR TITLE
configure_rabbitmq: add --user-config option

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Unreleased
 ----------
 * ``zocalo.configure_rabbitmq`` cli: require passing user config
   via explicit ``--user-config`` parameter
+* ``zocalo.configure_rabbitmq`` cli: optionally disable implicit
+  dlq creation via ``dead-letter-queue-create: false``
 
 0.20.0 (2022-06-17)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 Unreleased
 ----------
+* ``zocalo.configure_rabbitmq`` cli: require passing user config
+  via explicit ``--user-config`` parameter
 
 0.20.0 (2022-06-17)
 -------------------

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -137,6 +137,7 @@ def get_queue_specs(group: Dict) -> List[QueueSpec]:
     qtype = queue_settings.get("type", "classic")
     dlq_pattern = queue_settings.get("dead-letter-routing-key-pattern")
     dlq_exchange = queue_settings.get("dead-letter-exchange", "")
+    dlq_create = queue_settings.get("dead-letter-queue-create", True)
     vhost = group.get("vhost", "/")
     single_active_consumer = group.get("settings", {}).get(
         "single_active_consumer", False
@@ -165,7 +166,7 @@ def get_queue_specs(group: Dict) -> List[QueueSpec]:
     ]
 
     # Add dead-letter queues within the default exchange with the "dlq." prefix
-    if dlq_pattern:
+    if dlq_create and dlq_pattern:
         qspecs.extend(
             [
                 QueueSpec(


### PR DESCRIPTION
* This requires the user config file to be explicitly passed via the --user-config option rather than determined via the zocalo configuration. This makes it easier to use the same queue configuration file with different rabbitmq servers with (potentially) different users/passwords.

* Optionally disable implicit dlq creation: this enables using a queue that has already been explicitly defined elsewhere as a the dlq, allowing for more complex routing topologies.