### PR TITLE
Enable access to zocalo config through `BaseWrapper`

### DIFF
--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -113,8 +113,10 @@ def run():
     for field, value in zocalo.util.extended_status_dictionary().items():
         st.set_static_status_field(field, value)
 
+    environment = {"config": zc}
+
     # Instantiate chosen wrapper
-    instance = known_wrappers[args.wrapper]()()
+    instance = known_wrappers[args.wrapper]()(environment=environment)
     instance.status_thread = st
 
     # If specified, read in a serialized recipewrapper

--- a/src/zocalo/wrapper.py
+++ b/src/zocalo/wrapper.py
@@ -9,6 +9,9 @@ import zocalo
 
 
 class BaseWrapper:
+    def __init__(self, *args, **kwargs):
+        self._environment = kwargs.get("environment", {})
+
     def set_recipe_wrapper(self, recwrap):
         self.recwrap = recwrap
 
@@ -42,6 +45,10 @@ class BaseWrapper:
     def record_result_all_files(self, payload=""):
         if getattr(self, "recwrap", None):
             self.recwrap.send_to("result-all-files", payload)
+
+    @property
+    def config(self):
+        return self._environment.get("config")
 
 
 class DummyWrapper(BaseWrapper):


### PR DESCRIPTION
`environment` dict is optionally passed to `BaseWrapper` constructor, which then provides access via the `.config` property to the `zocalo.configuration` object stored under the "config" key of the `environment` dictionary.

This follows the similar interface as for workflows `CommonService`