### PR TITLE
zocalo.wrapper: use LoggerAdapter to append recipe_ID to logs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 Unreleased
 ----------
 * Remove deprecated ``zocalo.enable_graylog()`` function
+* Use ``LoggingAdapter`` to append ``recipe_ID`` to wrapper logs.
+  This was inadvertantly broken for the logging plugin added in #176.
+  Derived wrappers should now use self.log rather than instantiating
+  a logger directly.
 
 0.22.0 (2022-07-12)
 -------------------

--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -127,15 +127,6 @@ def run():
             )
         instance.set_recipe_wrapper(recwrap)
 
-        if zc.graylog and recwrap.environment.get("ID"):
-            # If recipe ID available then include that in all future log messages
-            class ContextFilter(logging.Filter):
-                def filter(self, record):
-                    record.recipe_ID = recwrap.environment["ID"]
-                    return True
-
-            zc.graylog.addFilter(ContextFilter())
-
         if recwrap.recipe_step.get("wrapper", {}).get("task_information"):
             # If the recipe contains an extra task_information field then add this to the status display
             st.taskname += (

--- a/src/zocalo/wrapper.py
+++ b/src/zocalo/wrapper.py
@@ -9,11 +9,18 @@ import zocalo
 
 
 class BaseWrapper:
+
+    _logger_name = "zocalo.wrapper"  # The logger can be accessed via self.log
+
     def __init__(self, *args, **kwargs):
         self._environment = kwargs.get("environment", {})
+        self.__log_extra = {}
+        logger = logging.getLogger(self._logger_name)
+        self.log = logging.LoggerAdapter(logger, extra=self.__log_extra)
 
     def set_recipe_wrapper(self, recwrap):
         self.recwrap = recwrap
+        self.__log_extra["recipe_ID"] = recwrap.environment["ID"]
 
     def prepare(self, payload=""):
         if getattr(self, "recwrap", None):
@@ -52,10 +59,11 @@ class BaseWrapper:
 
 
 class DummyWrapper(BaseWrapper):
+
+    _logger_name = "zocalo.wrapper.DummyWrapper"
+
     def run(self):
-        logging.getLogger("zocalo.wrapper.DummyWrapper").info(
-            "This is a dummy wrapper that simply waits for twenty seconds."
-        )
+        self.log.info("This is a dummy wrapper that simply waits for twenty seconds.")
         import time
 
         time.sleep(10)


### PR DESCRIPTION
Derived wrappers should now use `self.log.info()` etc rather than `logger.info()` to ensure the `recipe_ID` is included in the log message.

The inclusion of the `recipe_ID` in the log message was inadvertantly broken when using the new logging plugin #176

Fixes #192

Remove use of `ContextFilter` to add `recipe_ID` when using the graylog plugin as it is no longer needed since it is now already added using a LoggingAdapter.