### PR TITLE
Support for configuring rabbitmq vhosts

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased
 ----------
+* ``zocalo.configure_rabbitmq`` cli: enable configuration of vhosts
 
 0.23.0 (2022-08-02)
 -------------------

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -393,10 +393,11 @@ def run():
 
         # configure vhosts
         vhost_specs = get_vhost_specs(yaml_data.get("vhosts", []))
-        current_vhosts_excluding_default = [
-            vhost for vhost in api.vhosts() if vhost.name != "/"
-        ]
-        update_config(api, vhost_specs, current_vhosts_excluding_default)
+        if vhost_specs:
+            current_vhosts_excluding_default = [
+                vhost for vhost in api.vhosts() if vhost.name != "/"
+            ]
+            update_config(api, vhost_specs, current_vhosts_excluding_default)
 
         # configure policies
         _configure_policies(api, yaml_data["policies"])

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -5,7 +5,7 @@ import configparser
 import functools
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Dict, List, Tuple
 
 import requests
 import yaml
@@ -84,7 +84,7 @@ def _(comp: BindingSpec) -> bool:
 
 
 def update_config(
-    api: RabbitMQAPI, incoming: list[BaseModel], current: list[BaseModel]
+    api: RabbitMQAPI, incoming: List[BaseModel], current: List[BaseModel]
 ):
     cls = type(incoming[0])
     current = _info_to_spec(incoming[0], current)
@@ -107,7 +107,7 @@ def update_config(
             api.create_component(ic)
 
 
-def get_vhost_specs(vhosts: dict) -> list[VHostSpec]:
+def get_vhost_specs(vhosts: dict) -> List[VHostSpec]:
     vhost_specs = []
     for vhost in vhosts:
         vhost_specs.append(
@@ -121,7 +121,7 @@ def get_vhost_specs(vhosts: dict) -> list[VHostSpec]:
     return vhost_specs
 
 
-def get_binding_specs(bindings: dict) -> list[BindingSpec]:
+def get_binding_specs(bindings: dict) -> List[BindingSpec]:
     binding_specs = []
     for binding in bindings:
         binding_specs.append(
@@ -137,7 +137,7 @@ def get_binding_specs(bindings: dict) -> list[BindingSpec]:
     return binding_specs
 
 
-def get_binding_specs_for_group(group: dict) -> list[BindingSpec]:
+def get_binding_specs_for_group(group: dict) -> List[BindingSpec]:
     sources = group.get("bindings", [""])
     vhost = group.get("vhost", "/")
     return [
@@ -155,7 +155,7 @@ def get_binding_specs_for_group(group: dict) -> list[BindingSpec]:
     ]
 
 
-def get_queue_specs(group: dict) -> list[QueueSpec]:
+def get_queue_specs(group: dict) -> List[QueueSpec]:
     queue_settings = group.get("settings", {}).get("queues", {})
     qtype = queue_settings.get("type", "classic")
     dlq_pattern = queue_settings.get("dead-letter-routing-key-pattern")
@@ -211,7 +211,7 @@ def get_queue_specs(group: dict) -> list[QueueSpec]:
     return qspecs
 
 
-def get_exchange_specs(exchanges: dict) -> list[ExchangeSpec]:
+def get_exchange_specs(exchanges: dict) -> List[ExchangeSpec]:
     return [
         ExchangeSpec(
             **exchange,
@@ -220,7 +220,7 @@ def get_exchange_specs(exchanges: dict) -> list[ExchangeSpec]:
     ]
 
 
-def get_exchange_specs_for_group(group: dict) -> list[ExchangeSpec]:
+def get_exchange_specs_for_group(group: dict) -> List[ExchangeSpec]:
     vhost = group.get("vhost", "/")
     if group.get("settings", {}).get("broadcast"):
         etype = "fanout"
@@ -240,11 +240,11 @@ def get_exchange_specs_for_group(group: dict) -> list[ExchangeSpec]:
     ]
 
 
-def _configure_policies(api, policies: list[dict[str, Any]]):
+def _configure_policies(api, policies: List[Dict[str, Any]]):
     existing_policies = {
         (policy.vhost, policy.name): policy for policy in api.policies()
     }
-    known_policies: set[tuple[str, str]] = set()
+    known_policies: set[Tuple[str, str]] = set()
 
     for policy in policies:
         policy_id = (policy["vhost"], policy["name"])
@@ -274,9 +274,9 @@ def _configure_policies(api, policies: list[dict[str, Any]]):
         api.clear_policy(vhost=policy_id[0], name=policy_id[1])
 
 
-def _configure_queues(api, queues: list[QueueSpec]):
+def _configure_queues(api, queues: List[QueueSpec]):
     existing_queues = {(q.vhost, q.name): q for q in api.queues()}
-    known_queues: set[tuple[str, str]] = set()
+    known_queues: set[Tuple[str, str]] = set()
 
     for queue_spec in queues:
         queue_id = (queue_spec.vhost, queue_spec.name)
@@ -312,7 +312,7 @@ def _configure_queues(api, queues: list[QueueSpec]):
 def _configure_users(api, rabbitmq_user_config_area: Path):
     existing_users = {user.name: user for user in api.users()}
 
-    planned_users: dict[str, Path] = {}
+    planned_users: Dict[str, Path] = {}
     for config_file in rabbitmq_user_config_area.glob("**/*.ini"):
         try:
             config = configparser.ConfigParser()

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -9,7 +9,7 @@ import pathlib
 import secrets
 import urllib
 import urllib.request
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 import requests
 from pydantic import BaseModel, Field
@@ -153,6 +153,20 @@ class ConnectionInfo(BaseModel):
     )
 
 
+class VHostSpec(BaseModel):
+    name: str = Field(
+        ...,
+        description="The name of the virtual host entry.",
+    )
+    description: str = ""
+    tags: list[str] = Field(default_factory=list)
+    tracing: bool = False
+
+
+class VHostInfo(VHostSpec):
+    pass
+
+
 class NodeType(enum.Enum):
     disc = "disc"
     ram = "ram"
@@ -162,7 +176,7 @@ class NodeInfo(BaseModel):
     # applications	List of all Erlang applications running on the node.
     # auth_mechanisms	List of all SASL authentication mechanisms installed on the node.
     # cluster_links	A list of the other nodes in the cluster. For each node, there are details of the TCP connection used to connect to it and statistics on data that has been transferred.
-    config_files: Optional[List[pathlib.Path]] = Field(
+    config_files: Optional[list[pathlib.Path]] = Field(
         None, description="List of config files read by the node."
     )
     # contexts	List of all HTTP listeners on the node.
@@ -176,7 +190,7 @@ class NodeInfo(BaseModel):
     disk_free_limit: Optional[int] = Field(
         None, description="Point at which the disk alarm will go off."
     )
-    enabled_plugins: Optional[List[str]] = Field(
+    enabled_plugins: Optional[list[str]] = Field(
         None,
         description="List of plugins which are both explicitly enabled and running.",
     )
@@ -222,7 +236,7 @@ class NodeInfo(BaseModel):
     io_write_count: Optional[int] = Field(
         None, description="Total number of write operations by the persister."
     )
-    log_files: Optional[List[pathlib.Path]] = Field(
+    log_files: Optional[list[pathlib.Path]] = Field(
         None,
         description='List of log files used by the node. If the node also sends messages to stdout, "<stdout>" is also reported in the list.',
     )
@@ -349,7 +363,7 @@ class ExchangeSpec(BaseModel):
         False,
         description="Whether the exchange is internal, i.e. cannot be directly published to by a client.",
     )
-    arguments: Optional[Dict[str, Any]] = Field(
+    arguments: Optional[dict[str, Any]] = Field(
         default_factory=dict, description="Exchange arguments."
     )
     vhost: str = Field(
@@ -365,11 +379,11 @@ class ExchangeInfo(ExchangeSpec):
         None, description="Policy name for applying to the exchange."
     )
     message_stats: Optional[MessageStats] = None
-    incoming: Optional[Dict] = Field(
+    incoming: Optional[dict] = Field(
         None,
         description="Detailed message stats (see section above) for publishes from channels into this exchange.",
     )
-    outgoing: Optional[Dict] = Field(
+    outgoing: Optional[dict] = Field(
         None,
         description="Detailed message stats for publishes from this exchange into queues.",
     )
@@ -394,7 +408,7 @@ class PolicySpec(BaseModel):
         ...,
         description="The regular expression, which when matches on a given resources causes the policy to apply.",
     )
-    definition: Dict[str, Any] = Field(
+    definition: dict[str, Any] = Field(
         ...,
         description="A set of key/value pairs (think a JSON document) that will be injected into the map of optional arguments of the matching queues and exchanges.",
     )
@@ -434,7 +448,7 @@ class QueueSpec(BaseModel):
         False,
         description="Whether the queue will be deleted automatically when no longer used.",
     )
-    arguments: Optional[Dict[str, Any]] = Field(
+    arguments: Optional[dict[str, Any]] = Field(
         default_factory=dict, description="Queue arguments."
     )
     vhost: str = Field(
@@ -543,7 +557,7 @@ class QueueInfo(QueueSpec):
         None,
         description="Detailed message stats for deliveries from this queue into channels.",
     )
-    consumer_details: Optional[List[Any]] = Field(
+    consumer_details: Optional[list[Any]] = Field(
         None,
         description="List of consumers on this channel, with some details on each.",
     )
@@ -567,7 +581,7 @@ class UserSpec(BaseModel):
     name: str = Field(..., description="Username")
     password_hash: str = Field(..., description="Hash of the user password.")
     hashing_algorithm: HashingAlgorithm
-    tags: List[str]
+    tags: list[str]
 
     class Config:
         use_enum_values = True
@@ -632,7 +646,7 @@ class RabbitMQAPI:
         return instance
 
     @property
-    def health_checks(self) -> Tuple[Dict[str, Any], Dict[str, str]]:
+    def health_checks(self) -> tuple[dict[str, Any], dict[str, str]]:
         # https://rawcdn.githack.com/rabbitmq/rabbitmq-server/v3.9.7/deps/rabbitmq_management/priv/www/api/index.html
         HEALTH_CHECKS = {
             "health/checks/alarms",
@@ -657,7 +671,7 @@ class RabbitMQAPI:
         return success, failure
 
     def get(
-        self, endpoint: str, params: Dict[str, Any] = None, timeout: float | None = None
+        self, endpoint: str, params: dict[str, Any] = None, timeout: float | None = None
     ) -> requests.Response:
         return self._session.get(
             f"{self._url}/{endpoint}", params=params, timeout=timeout
@@ -666,8 +680,8 @@ class RabbitMQAPI:
     def put(
         self,
         endpoint: str,
-        params: Dict[str, Any] = None,
-        json: Dict[str, Any] = None,
+        params: dict[str, Any] = None,
+        json: dict[str, Any] = None,
         timeout: float | None = None,
     ) -> requests.Response:
         return self._session.put(
@@ -677,8 +691,8 @@ class RabbitMQAPI:
     def post(
         self,
         endpoint: str,
-        data: Optional[Dict[str, Any]] = None,
-        json: Optional[Dict[str, Any]] = None,
+        data: Optional[dict[str, Any]] = None,
+        json: Optional[dict[str, Any]] = None,
         timeout: float | None = None,
     ) -> requests.Response:
         return self._session.post(
@@ -686,7 +700,7 @@ class RabbitMQAPI:
         )
 
     def delete(
-        self, endpoint: str, params: Dict[str, Any] = None, timeout: float | None = None
+        self, endpoint: str, params: dict[str, Any] = None, timeout: float | None = None
     ) -> requests.Response:
         return self._session.delete(
             f"{self._url}/{endpoint}", params=params, timeout=timeout
@@ -698,7 +712,7 @@ class RabbitMQAPI:
         source: Optional[str] = None,
         destination: Optional[str] = None,
         destination_type: Optional[str] = None,
-    ) -> List[BindingInfo]:
+    ) -> list[BindingInfo]:
         endpoint = "bindings"
         if vhost is not None:
             endpoint = f"{endpoint}/{vhost}"
@@ -761,7 +775,7 @@ class RabbitMQAPI:
 
     def connections(
         self, name: Optional[str] = None
-    ) -> Union[List[ConnectionInfo], ConnectionInfo]:
+    ) -> Union[list[ConnectionInfo], ConnectionInfo]:
         endpoint = "connections"
         if name is not None:
             endpoint = f"{endpoint}/{name}/"
@@ -770,7 +784,7 @@ class RabbitMQAPI:
         response = self.get(endpoint)
         return [ConnectionInfo(**qi) for qi in response.json()]
 
-    def nodes(self, name: Optional[str] = None) -> Union[List[NodeInfo], NodeInfo]:
+    def nodes(self, name: Optional[str] = None) -> Union[list[NodeInfo], NodeInfo]:
         # https://www.rabbitmq.com/monitoring.html#node-metrics
         endpoint = "nodes"
         if name is not None:
@@ -782,7 +796,7 @@ class RabbitMQAPI:
 
     def exchanges(
         self, vhost: Optional[str] = None, name: Optional[str] = None
-    ) -> Union[List[ExchangeInfo], ExchangeInfo]:
+    ) -> Union[list[ExchangeInfo], ExchangeInfo]:
         endpoint = "exchanges"
         if vhost is not None and name is not None:
             endpoint = f"{endpoint}/{vhost}/{name}/"
@@ -808,7 +822,7 @@ class RabbitMQAPI:
         response = self.delete(endpoint, params={"if-unused": if_unused})
         response.raise_for_status()
 
-    def policies(self, vhost: Optional[str] = None) -> List[PolicySpec]:
+    def policies(self, vhost: Optional[str] = None) -> list[PolicySpec]:
         endpoint = "policies"
         if vhost is not None:
             endpoint = f"{endpoint}/{vhost}/"
@@ -837,7 +851,7 @@ class RabbitMQAPI:
 
     def queues(
         self, vhost: Optional[str] = None, name: Optional[str] = None
-    ) -> Union[List[QueueInfo], QueueInfo]:
+    ) -> Union[list[QueueInfo], QueueInfo]:
         endpoint = "queues"
         if vhost is not None and name is not None:
             endpoint = f"{endpoint}/{vhost}/{name}"
@@ -866,7 +880,7 @@ class RabbitMQAPI:
         )
         response.raise_for_status()
 
-    def users(self) -> List[UserSpec]:
+    def users(self) -> list[UserSpec]:
         endpoint = "users"
         response = self.get(endpoint)
         return [UserSpec(**user) for user in response.json()]
@@ -885,6 +899,28 @@ class RabbitMQAPI:
 
     def user_delete(self, name: str):
         endpoint = f"users/{name}/"
+        response = self.delete(endpoint)
+        response.raise_for_status()
+
+    def vhosts(self) -> list[VHostInfo]:
+        endpoint = "vhosts"
+        response = self.get(endpoint)
+        return [VHostInfo(**user) for user in response.json()]
+
+    def vhost(self, name: str) -> VHostInfo:
+        endpoint = f"vhosts/{name}/"
+        response = self.get(endpoint).json()
+        return VHostInfo(**response)
+
+    def add_vhost(self, vhost: VHostSpec):
+        endpoint = f"vhosts/{vhost.name}/"
+        response = self.put(
+            endpoint, json=vhost.dict(exclude_defaults=True, exclude={"name", "vhost"})
+        )
+        response.raise_for_status()
+
+    def delete_vhost(self, name: str):
+        endpoint = f"vhosts/{name}/"
         response = self.delete(endpoint)
         response.raise_for_status()
 

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -163,8 +163,43 @@ class VHostSpec(BaseModel):
     tracing: bool = False
 
 
-class VHostInfo(VHostSpec):
-    pass
+class PermissionSpec(BaseModel):
+    """Sets user permissions.
+
+    For example, this instructs the RabbitMQ broker to grant the user named
+    "janeway" access to the virtual host called "my-vhost", with configure
+    permissions on all resources whose names starts with "janeway-", and
+    write and read permissions on all resources:
+
+        PermissionSpec(
+            vhost="my-vhost",
+            user="janeway",
+            configure="^janeway-.*",
+            write=".*",
+            read=".*",
+        )
+    """
+
+    vhost: str = Field(
+        ...,
+        description='The name of the virtual host to which to grant the user access, defaulting to "/".',
+    )
+    user: str = Field(
+        ...,
+        description="The name of the user to grant access to the specified virtual host.",
+    )
+    configure: str = Field(
+        ...,
+        description="A regular expression matching resource names for which the user is granted configure permissions.",
+    )
+    write: str = Field(
+        ...,
+        description="A regular expression matching resource names for which the user is granted write permissions.",
+    )
+    read: str = Field(
+        ...,
+        description="A regular expression matching resource names for which the user is granted read permissions.",
+    )
 
 
 class NodeType(enum.Enum):
@@ -890,6 +925,32 @@ class RabbitMQAPI:
         response = self.get(endpoint).json()
         return UserSpec(**response)
 
+    def permissions(
+        self, vhost: Optional[str] = None, user: Optional[str] = None
+    ) -> List[PermissionSpec] | PermissionSpec:
+        endpoint = "permissions"
+        if vhost is not None and user is not None:
+            endpoint = f"{endpoint}/{vhost}/{user}/"
+            response = self.get(endpoint)
+            return PermissionSpec(**response.json())
+        elif vhost is not None or user is not None:
+            raise ValueError(
+                "Either both or neither of vhost and user must be set to None"
+            )
+        response = self.get(endpoint)
+        return [PermissionSpec(**ps) for ps in response.json()]
+
+    def set_permissions(self, permission: PermissionSpec):
+        endpoint = f"permissions/{permission.vhost}/{permission.user}/"
+        submission = permission.dict(exclude_defaults=True, exclude={"vhost", "user"})
+        response = self.put(endpoint, json=submission)
+        response.raise_for_status()
+
+    def clear_permissions(self, vhost: str, user: str):
+        endpoint = f"permissions/{vhost}/{user}/"
+        response = self.delete(endpoint)
+        response.raise_for_status()
+
     def user_put(self, user: UserSpec):
         endpoint = f"users/{user.name}/"
         submission = user.dict(exclude_defaults=True, exclude={"name"})
@@ -902,15 +963,15 @@ class RabbitMQAPI:
         response = self.delete(endpoint)
         response.raise_for_status()
 
-    def vhosts(self) -> List[VHostInfo]:
+    def vhosts(self) -> List[VHostSpec]:
         endpoint = "vhosts"
         response = self.get(endpoint)
-        return [VHostInfo(**user) for user in response.json()]
+        return [VHostSpec(**user) for user in response.json()]
 
-    def vhost(self, name: str) -> VHostInfo:
+    def vhost(self, name: str) -> VHostSpec:
         endpoint = f"vhosts/{name}/"
         response = self.get(endpoint).json()
-        return VHostInfo(**response)
+        return VHostSpec(**response)
 
     def add_vhost(self, vhost: VHostSpec):
         endpoint = f"vhosts/{vhost.name}/"

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -9,7 +9,7 @@ import pathlib
 import secrets
 import urllib
 import urllib.request
-from typing import Any, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
 from pydantic import BaseModel, Field
@@ -159,7 +159,7 @@ class VHostSpec(BaseModel):
         description="The name of the virtual host entry.",
     )
     description: str = ""
-    tags: list[str] = Field(default_factory=list)
+    tags: List[str] = Field(default_factory=list)
     tracing: bool = False
 
 
@@ -176,7 +176,7 @@ class NodeInfo(BaseModel):
     # applications	List of all Erlang applications running on the node.
     # auth_mechanisms	List of all SASL authentication mechanisms installed on the node.
     # cluster_links	A list of the other nodes in the cluster. For each node, there are details of the TCP connection used to connect to it and statistics on data that has been transferred.
-    config_files: Optional[list[pathlib.Path]] = Field(
+    config_files: Optional[List[pathlib.Path]] = Field(
         None, description="List of config files read by the node."
     )
     # contexts	List of all HTTP listeners on the node.
@@ -190,7 +190,7 @@ class NodeInfo(BaseModel):
     disk_free_limit: Optional[int] = Field(
         None, description="Point at which the disk alarm will go off."
     )
-    enabled_plugins: Optional[list[str]] = Field(
+    enabled_plugins: Optional[List[str]] = Field(
         None,
         description="List of plugins which are both explicitly enabled and running.",
     )
@@ -236,7 +236,7 @@ class NodeInfo(BaseModel):
     io_write_count: Optional[int] = Field(
         None, description="Total number of write operations by the persister."
     )
-    log_files: Optional[list[pathlib.Path]] = Field(
+    log_files: Optional[List[pathlib.Path]] = Field(
         None,
         description='List of log files used by the node. If the node also sends messages to stdout, "<stdout>" is also reported in the list.',
     )
@@ -363,7 +363,7 @@ class ExchangeSpec(BaseModel):
         False,
         description="Whether the exchange is internal, i.e. cannot be directly published to by a client.",
     )
-    arguments: Optional[dict[str, Any]] = Field(
+    arguments: Optional[Dict[str, Any]] = Field(
         default_factory=dict, description="Exchange arguments."
     )
     vhost: str = Field(
@@ -408,7 +408,7 @@ class PolicySpec(BaseModel):
         ...,
         description="The regular expression, which when matches on a given resources causes the policy to apply.",
     )
-    definition: dict[str, Any] = Field(
+    definition: Dict[str, Any] = Field(
         ...,
         description="A set of key/value pairs (think a JSON document) that will be injected into the map of optional arguments of the matching queues and exchanges.",
     )
@@ -448,7 +448,7 @@ class QueueSpec(BaseModel):
         False,
         description="Whether the queue will be deleted automatically when no longer used.",
     )
-    arguments: Optional[dict[str, Any]] = Field(
+    arguments: Optional[Dict[str, Any]] = Field(
         default_factory=dict, description="Queue arguments."
     )
     vhost: str = Field(
@@ -557,7 +557,7 @@ class QueueInfo(QueueSpec):
         None,
         description="Detailed message stats for deliveries from this queue into channels.",
     )
-    consumer_details: Optional[list[Any]] = Field(
+    consumer_details: Optional[List[Any]] = Field(
         None,
         description="List of consumers on this channel, with some details on each.",
     )
@@ -581,7 +581,7 @@ class UserSpec(BaseModel):
     name: str = Field(..., description="Username")
     password_hash: str = Field(..., description="Hash of the user password.")
     hashing_algorithm: HashingAlgorithm
-    tags: list[str]
+    tags: List[str]
 
     class Config:
         use_enum_values = True
@@ -646,7 +646,7 @@ class RabbitMQAPI:
         return instance
 
     @property
-    def health_checks(self) -> tuple[dict[str, Any], dict[str, str]]:
+    def health_checks(self) -> Tuple[Dict[str, Any], Dict[str, str]]:
         # https://rawcdn.githack.com/rabbitmq/rabbitmq-server/v3.9.7/deps/rabbitmq_management/priv/www/api/index.html
         HEALTH_CHECKS = {
             "health/checks/alarms",
@@ -671,7 +671,7 @@ class RabbitMQAPI:
         return success, failure
 
     def get(
-        self, endpoint: str, params: dict[str, Any] = None, timeout: float | None = None
+        self, endpoint: str, params: Dict[str, Any] = None, timeout: float | None = None
     ) -> requests.Response:
         return self._session.get(
             f"{self._url}/{endpoint}", params=params, timeout=timeout
@@ -680,8 +680,8 @@ class RabbitMQAPI:
     def put(
         self,
         endpoint: str,
-        params: dict[str, Any] = None,
-        json: dict[str, Any] = None,
+        params: Dict[str, Any] = None,
+        json: Dict[str, Any] = None,
         timeout: float | None = None,
     ) -> requests.Response:
         return self._session.put(
@@ -691,8 +691,8 @@ class RabbitMQAPI:
     def post(
         self,
         endpoint: str,
-        data: Optional[dict[str, Any]] = None,
-        json: Optional[dict[str, Any]] = None,
+        data: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
         timeout: float | None = None,
     ) -> requests.Response:
         return self._session.post(
@@ -700,7 +700,7 @@ class RabbitMQAPI:
         )
 
     def delete(
-        self, endpoint: str, params: dict[str, Any] = None, timeout: float | None = None
+        self, endpoint: str, params: Dict[str, Any] = None, timeout: float | None = None
     ) -> requests.Response:
         return self._session.delete(
             f"{self._url}/{endpoint}", params=params, timeout=timeout
@@ -712,7 +712,7 @@ class RabbitMQAPI:
         source: Optional[str] = None,
         destination: Optional[str] = None,
         destination_type: Optional[str] = None,
-    ) -> list[BindingInfo]:
+    ) -> List[BindingInfo]:
         endpoint = "bindings"
         if vhost is not None:
             endpoint = f"{endpoint}/{vhost}"
@@ -775,7 +775,7 @@ class RabbitMQAPI:
 
     def connections(
         self, name: Optional[str] = None
-    ) -> Union[list[ConnectionInfo], ConnectionInfo]:
+    ) -> Union[List[ConnectionInfo], ConnectionInfo]:
         endpoint = "connections"
         if name is not None:
             endpoint = f"{endpoint}/{name}/"
@@ -784,7 +784,7 @@ class RabbitMQAPI:
         response = self.get(endpoint)
         return [ConnectionInfo(**qi) for qi in response.json()]
 
-    def nodes(self, name: Optional[str] = None) -> Union[list[NodeInfo], NodeInfo]:
+    def nodes(self, name: Optional[str] = None) -> Union[List[NodeInfo], NodeInfo]:
         # https://www.rabbitmq.com/monitoring.html#node-metrics
         endpoint = "nodes"
         if name is not None:
@@ -796,7 +796,7 @@ class RabbitMQAPI:
 
     def exchanges(
         self, vhost: Optional[str] = None, name: Optional[str] = None
-    ) -> Union[list[ExchangeInfo], ExchangeInfo]:
+    ) -> Union[List[ExchangeInfo], ExchangeInfo]:
         endpoint = "exchanges"
         if vhost is not None and name is not None:
             endpoint = f"{endpoint}/{vhost}/{name}/"
@@ -822,7 +822,7 @@ class RabbitMQAPI:
         response = self.delete(endpoint, params={"if-unused": if_unused})
         response.raise_for_status()
 
-    def policies(self, vhost: Optional[str] = None) -> list[PolicySpec]:
+    def policies(self, vhost: Optional[str] = None) -> List[PolicySpec]:
         endpoint = "policies"
         if vhost is not None:
             endpoint = f"{endpoint}/{vhost}/"
@@ -851,7 +851,7 @@ class RabbitMQAPI:
 
     def queues(
         self, vhost: Optional[str] = None, name: Optional[str] = None
-    ) -> Union[list[QueueInfo], QueueInfo]:
+    ) -> Union[List[QueueInfo], QueueInfo]:
         endpoint = "queues"
         if vhost is not None and name is not None:
             endpoint = f"{endpoint}/{vhost}/{name}"
@@ -880,7 +880,7 @@ class RabbitMQAPI:
         )
         response.raise_for_status()
 
-    def users(self) -> list[UserSpec]:
+    def users(self) -> List[UserSpec]:
         endpoint = "users"
         response = self.get(endpoint)
         return [UserSpec(**user) for user in response.json()]
@@ -902,7 +902,7 @@ class RabbitMQAPI:
         response = self.delete(endpoint)
         response.raise_for_status()
 
-    def vhosts(self) -> list[VHostInfo]:
+    def vhosts(self) -> List[VHostInfo]:
         endpoint = "vhosts"
         response = self.get(endpoint)
         return [VHostInfo(**user) for user in response.json()]

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -408,6 +408,71 @@ def test_api_delete_user(requests_mock, rmqapi, user_spec):
     assert history.url.endswith("/api/users/guest/")
 
 
+def test_api_permissions(requests_mock, rmqapi):
+    permissions = [
+        {
+            "vhost": "my-vhost",
+            "user": "janeway",
+            "configure": "^janeway-.*",
+            "write": ".*",
+            "read": ".*",
+        },
+        {
+            "vhost": "my-vhost",
+            "user": "admin",
+            "configure": "^.*",
+            "write": ".*",
+            "read": ".*",
+        },
+    ]
+
+    # First call rmq.permissions() with defaults
+    requests_mock.get("/api/permissions", json=permissions)
+    assert rmqapi.permissions() == [rabbitmq.PermissionSpec(**p) for p in permissions]
+
+    # Now call with name=...
+    requests_mock.get("/api/permissions/my-vhost/janeway/", json=permissions[0])
+    assert rmqapi.permissions(
+        vhost="my-vhost", user="janeway"
+    ) == rabbitmq.PermissionSpec(**permissions[0])
+
+
+@pytest.fixture
+def permission_spec():
+    return rabbitmq.PermissionSpec(
+        vhost="my-vhost",
+        user="janeway",
+        configure="^janeway-.*",
+        write=".*",
+        read=".*",
+    )
+
+
+def test_api_add_permissions(requests_mock, rmqapi, permission_spec):
+    endpoint = f"/api/permissions/{permission_spec.vhost}/{permission_spec.user}/"
+    requests_mock.put(endpoint)
+    rmqapi.set_permissions(permission_spec)
+    assert requests_mock.call_count == 1
+    history = requests_mock.request_history[0]
+    assert history.method == "PUT"
+    assert history.url.endswith(endpoint)
+    assert history.json() == {
+        "configure": "^janeway-.*",
+        "write": ".*",
+        "read": ".*",
+    }
+
+
+def test_api_clear_permissions(requests_mock, rmqapi):
+    endpoint = "/api/permissions/foo/bar/"
+    requests_mock.delete(endpoint)
+    rmqapi.clear_permissions(vhost="foo", user="bar")
+    assert requests_mock.call_count == 1
+    history = requests_mock.request_history[0]
+    assert history.method == "DELETE"
+    assert history.url.endswith(endpoint)
+
+
 def test_api_vhosts(requests_mock, rmqapi):
     vhosts = [
         {
@@ -426,16 +491,16 @@ def test_api_vhosts(requests_mock, rmqapi):
 
     # First call rmq.users() with defaults
     requests_mock.get("/api/vhosts", json=vhosts)
-    assert rmqapi.vhosts() == [rabbitmq.VHostInfo(**vhost) for vhost in vhosts]
+    assert rmqapi.vhosts() == [rabbitmq.VHostSpec(**vhost) for vhost in vhosts]
 
     # Now call with name=...
     requests_mock.get("/api/vhosts/foo/", json=vhosts[0])
-    assert rmqapi.vhost("foo") == rabbitmq.VHostInfo(**vhosts[0])
+    assert rmqapi.vhost("foo") == rabbitmq.VHostSpec(**vhosts[0])
 
 
 @pytest.fixture
 def vhost_spec():
-    return rabbitmq.VHostInfo(
+    return rabbitmq.VHostSpec(
         name="foo",
     )
 


### PR DESCRIPTION
Without this, vhosts had to be configured manually ahead of running this script. With this PR, it should be possible to correctly configure a clean RabbitMQ server.