### PR TITLE
Downgrade no matching queue error to warning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased
 ----------
+* ``zocalo.configure_rabbitmq`` cli: downgrade "No matching queue found" error to warning
 
 0.24.1 (2022-08-24)
 -------------------

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -449,8 +449,7 @@ def run():
                     if qu.vhost == b.vhost and qu.name == b.destination
                 ][0]
             except IndexError:
-                logger.error(f"No matching queue found binding {b}\n{queues=}")
-                raise
+                logger.warning(f"No matching queue found binding {b}")
             else:
                 if q.auto_delete or q.exclusive:
                     continue


### PR DESCRIPTION
I think this can be triggered by the creation of temporary queues (for example by the Zocalo system tests) between the api.queues() and api.bindings() calls.