### PR TITLE
Expose various attributes on SlurmRestApi instances

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 Unreleased
 ----------
+* Expose ``url``, ``version``, ``user_name`` and ``user_token`` attributes on ``SlurmRestApi`` instances
 
 0.28.0 (2023-03-20)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 Unreleased
 ----------
 * Expose ``url``, ``version``, ``user_name`` and ``user_token`` attributes on ``SlurmRestApi`` instances
+* Load ``user_token`` from external file in ``SlurmRestApi`` rather than in the ``zocalo.configuration`` Slurm plugin to allow token changes to be picked up without re-loading ``zocalo.configuration``
 
 0.28.0 (2023-03-20)
 -------------------

--- a/src/zocalo/configuration/plugin_slurm.py
+++ b/src/zocalo/configuration/plugin_slurm.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 from marshmallow import fields
 
 from zocalo.configuration import PluginSchema
@@ -16,8 +14,4 @@ class Slurm:
 
     @staticmethod
     def activate(configuration):
-        user_token = configuration.get("user_token")
-        if user_token and os.path.isfile(user_token):
-            with open(user_token, "r") as f:
-                configuration["user_token"] = f.read().strip()
         return configuration

--- a/src/zocalo/util/slurm/__init__.py
+++ b/src/zocalo/util/slurm/__init__.py
@@ -17,13 +17,15 @@ class SlurmRestApi:
         user_name: Optional[str] = None,
         user_token: Optional[str] = None,
     ):
-        self._url = url
-        self._version = version
-        self._session = requests.Session()
+        self.url = url
+        self.version = version
+        self.user_name = user_name
+        self.user_token = user_token
+        self.session = requests.Session()
         if user_name:
-            self._session.headers["X-SLURM-USER-NAME"] = user_name
+            self.session.headers["X-SLURM-USER-NAME"] = user_name
         if user_token:
-            self._session.headers["X-SLURM-USER-TOKEN"] = user_token
+            self.session.headers["X-SLURM-USER-TOKEN"] = user_token
 
     @classmethod
     def from_zocalo_configuration(cls, zc: zocalo.configuration.Configuration):
@@ -37,8 +39,8 @@ class SlurmRestApi:
     def get(
         self, endpoint: str, params: dict[str, Any] = None, timeout: float | None = None
     ) -> requests.Response:
-        response = self._session.get(
-            f"{self._url}/{endpoint}", params=params, timeout=timeout
+        response = self.session.get(
+            f"{self.url}/{endpoint}", params=params, timeout=timeout
         )
         response.raise_for_status()
         return response
@@ -50,8 +52,8 @@ class SlurmRestApi:
         json: dict[str, Any] = None,
         timeout: float | None = None,
     ) -> requests.Response:
-        response = self._session.put(
-            f"{self._url}/{endpoint}", params=params, json=json, timeout=timeout
+        response = self.session.put(
+            f"{self.url}/{endpoint}", params=params, json=json, timeout=timeout
         )
         response.raise_for_status()
         return response
@@ -63,8 +65,8 @@ class SlurmRestApi:
         json: dict[str, Any] | None = None,
         timeout: float | None = None,
     ) -> requests.Response:
-        response = self._session.post(
-            f"{self._url}/{endpoint}", data=data, json=json, timeout=timeout
+        response = self.session.post(
+            f"{self.url}/{endpoint}", data=data, json=json, timeout=timeout
         )
         response.raise_for_status()
         return response
@@ -72,25 +74,25 @@ class SlurmRestApi:
     def delete(
         self, endpoint: str, params: dict[str, Any] = None, timeout: float | None = None
     ) -> requests.Response:
-        response = self._session.delete(
-            f"{self._url}/{endpoint}", params=params, timeout=timeout
+        response = self.session.delete(
+            f"{self.url}/{endpoint}", params=params, timeout=timeout
         )
         response.raise_for_status()
         return response
 
     def get_jobs(self) -> models.JobsResponse:
-        endpoint = f"slurm/{self._version}/jobs"
+        endpoint = f"slurm/{self.version}/jobs"
         response = self.get(endpoint)
         return models.JobsResponse(**response.json())
 
     def get_job_info(self, job_id: int) -> models.JobsResponse:
-        endpoint = f"slurm/{self._version}/job/{job_id}"
+        endpoint = f"slurm/{self.version}/job/{job_id}"
         response = self.get(endpoint)
         return models.JobsResponse(**response.json())
 
     def submit_job(
         self, job_submission: models.JobSubmission
     ) -> models.JobSubmissionResponse:
-        endpoint = f"slurm/{self._version}/job/submit"
+        endpoint = f"slurm/{self.version}/job/submit"
         response = self.post(endpoint, json=job_submission.dict(exclude_defaults=True))
         return models.JobSubmissionResponse(**response.json())

--- a/src/zocalo/util/slurm/__init__.py
+++ b/src/zocalo/util/slurm/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+import os
+import pathlib
+from typing import Any
 
 import requests
 
@@ -14,18 +16,23 @@ class SlurmRestApi:
         self,
         url: str,
         version: str = "v0.0.36",
-        user_name: Optional[str] = None,
-        user_token: Optional[str] = None,
+        user_name: str | None = None,
+        user_token: str | pathlib.Path | None = None,
     ):
         self.url = url
         self.version = version
         self.user_name = user_name
-        self.user_token = user_token
+        if user_token and os.path.isfile(user_token):
+            with open(user_token, "r") as f:
+                self.user_token = f.read().strip()
+        else:
+            assert isinstance(user_token, str)
+            self.user_token = user_token
         self.session = requests.Session()
-        if user_name:
-            self.session.headers["X-SLURM-USER-NAME"] = user_name
-        if user_token:
-            self.session.headers["X-SLURM-USER-TOKEN"] = user_token
+        if self.user_name:
+            self.session.headers["X-SLURM-USER-NAME"] = self.user_name
+        if self.user_token:
+            self.session.headers["X-SLURM-USER-TOKEN"] = self.user_token
 
     @classmethod
     def from_zocalo_configuration(cls, zc: zocalo.configuration.Configuration):

--- a/tests/configuration/test_plugin_slurm.py
+++ b/tests/configuration/test_plugin_slurm.py
@@ -81,7 +81,7 @@ environments:
     assert zc.slurm is None
     zc.activate_environment("live")
     assert isinstance(zc.slurm, dict)
-    assert zc.slurm["user_token"] == user_token
+    assert zc.slurm["user_token"] == str(user_token_file)
 
 
 def test_invalid_config():

--- a/tests/util/test_slurm.py
+++ b/tests/util/test_slurm.py
@@ -77,6 +77,13 @@ def jobs_response():
     }
 
 
+def test_get_slurm_api_from_zocalo_configuration(slurm_api):
+    assert slurm_api.url == "http://slurm.example.com:1234"
+    assert slurm_api.version == "v0.0.36"
+    assert slurm_api.user_name == "foo"
+    assert slurm_api.user_token == "sometoken"
+
+
 def test_get_jobs(requests_mock, slurm_api, jobs_response):
     requests_mock.get(
         "/slurm/v0.0.36/jobs",

--- a/tests/util/test_slurm.py
+++ b/tests/util/test_slurm.py
@@ -84,6 +84,18 @@ def test_get_slurm_api_from_zocalo_configuration(slurm_api):
     assert slurm_api.user_token == "sometoken"
 
 
+def test_get_slurm_api_user_token_external_file(tmp_path):
+    user_token_file = tmp_path / "slurm-user-token"
+    user_token_file.write_text("foobar")
+    api = slurm.SlurmRestApi(
+        url="http://slurm.example.com:1234",
+        version="v0.0.36",
+        user_name="foo",
+        user_token=user_token_file,
+    )
+    assert api.user_token == "foobar"
+
+
 def test_get_jobs(requests_mock, slurm_api, jobs_response):
     requests_mock.get(
         "/slurm/v0.0.36/jobs",


### PR DESCRIPTION
So that downstream applications can e.g. check expiry on the user token