### PR TITLE
Fix and freeze dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,11 +1,10 @@
 PyYAML==6.0
 graypy==2.1.0
 marshmallow==3.19.0
-pydantic
+pydantic==1.10.12
 pytest-cov==4.1.0
-pytest-mock
+pytest-mock==3.11.1
 pytest==7.4.0
-requests
-requests_mock
-setuptools==68.0.0
+requests==2.31.0
+requests_mock==1.11.0
 workflows==2.26

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,2 +1,2 @@
-Sphinx==7.0.1
+Sphinx==6.2.1
 sphinx-rtd-theme==1.2.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     graypy>=1.0
     marshmallow
     requests
-    pydantic
+    pydantic<2
     setuptools
     workflows>=2.14
 packages = find:


### PR DESCRIPTION
sphinx-rtd-theme wasn't compatible with updated sphinx. We can update this separately.

Also, zocalo isn't compatible with pydantic 2 yet.

Freeze other dependencies listed in `requirements_dev.txt` - the whole purpose of having a requirements file is freezing the direct dependencies.