### PR TITLE
Bump version: 0.30.2 → 0.32.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.30.2
+current_version = 0.32.0
 commit = True
 tag = True
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,11 @@ History
 
 Unreleased
 ----------
-* ``zocalo.configure_rabbitmq``: Show explicit error when VHost not created.
+
+0.32.0 (2024-04-05)
+-------------------
+* Upgrade to Slurm REST API v0.0.40. (`#248 <https://github.com/DiamondLightSource/python-zocalo/pull/248>`_)
+* ``zocalo.configure_rabbitmq``: Show explicit error when VHost not created. (`#241 <https://github.com/DiamondLightSource/python-zocalo/pull/241>`_).
 
 0.30.2 (2023-09-06)
 -------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Zocalo"
-copyright = "2020, Diamond Light Source"
+copyright = "2024, Diamond Light Source"
 author = "Scientific Software"
 
 # The version info for the project you're documenting, acts as replacement
@@ -59,7 +59,7 @@ author = "Scientific Software"
 # the built documents.
 #
 # The short X.Y version.
-version = "0.30.2"
+version = "0.32.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zocalo"
-version = "0.30.2"
+version = "0.32.0"
 description = "Infrastructure components for automated data processing at Diamond Light Source"
 readme = "README.rst"
 requires-python = ">=3.8"

--- a/src/zocalo/__init__.py
+++ b/src/zocalo/__init__.py
@@ -6,7 +6,7 @@ import logging
 
 __author__ = "Diamond Light Source - Data Analysis Group"
 __email__ = "dataanalysis@diamond.ac.uk"
-__version__ = "0.30.2"
+__version__ = "0.32.0"
 
 logging.getLogger("zocalo").addHandler(logging.NullHandler())
 


### PR DESCRIPTION
Zocalo version v0.32.0 release

 * Upgrade to Slurm REST API v0.0.40. [#248](https://github.com/DiamondLightSource/python-zocalo/pull/248)
 * ``zocalo.configure_rabbitmq``: Show explicit error when VHost not created. [#241](https://github.com/DiamondLightSource/python-zocalo/pull/241)