### PR TITLE
Upgrade pydantic to v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "graypy>=1.0",
     "marshmallow",
     "requests",
-    "pydantic<2",
+    "pydantic",
     "setuptools",
     "workflows>=2.14",
 ]

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -12,7 +12,7 @@ import urllib.request
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import requests
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, BaseModel, Field
 from workflows.transport import pika_transport
 
 import zocalo.configuration
@@ -361,7 +361,7 @@ class BindingSpec(BaseModel):
         ..., description="Virtual host name with non-ASCII characters escaped as in C."
     )
     routing_key: str = Field("", description="Routing key attached to binding")
-    arguments: Optional[dict] = Field(
+    arguments: dict = Field(
         default_factory=dict, description="Binding arguments"
     )
 
@@ -404,9 +404,7 @@ class ExchangeSpec(BaseModel):
     vhost: str = Field(
         ..., description="Virtual host name with non-ASCII characters escaped as in C."
     )
-
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 class ExchangeInfo(ExchangeSpec):
@@ -456,11 +454,7 @@ class PolicySpec(BaseModel):
         alias="apply-to",
         description="Which types of object this policy should apply to.",
     )
-
-    class Config:
-        use_enum_values = True
-        validate_all = True
-        allow_population_by_field_name = True
+    model_config = ConfigDict(use_enum_values=True, validate_default=True, populate_by_name=True)
 
 
 class QueueState(str, enum.Enum):
@@ -617,9 +611,7 @@ class UserSpec(BaseModel):
     password_hash: str = Field(..., description="Hash of the user password.")
     hashing_algorithm: HashingAlgorithm
     tags: List[str]
-
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
 
 def http_api_request(

--- a/src/zocalo/util/slurm/models.py
+++ b/src/zocalo/util/slurm/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import ConfigDict, BaseModel, Field
 
 
 class Exclusive(Enum):
@@ -29,8 +29,7 @@ class Error(BaseModel):
 
 
 class JobProperties(BaseModel):
-    class Config:
-        use_enum_values = True
+    model_config = ConfigDict(use_enum_values=True)
 
     account: Optional[str] = Field(
         None, description="Charge resources used by this job to specified account."
@@ -177,9 +176,9 @@ class JobProperties(BaseModel):
     nodes: Optional[List[int]] = Field(
         None,
         description="Request that a minimum of minnodes nodes and a maximum node count.",
-        max_items=2,
+        max_length=2,
         # min_items=1, XXX
-        min_items=2,
+        min_length=2,
     )
     open_mode: Optional[OpenMode] = Field(
         "append",
@@ -208,7 +207,7 @@ class JobProperties(BaseModel):
     signal: Optional[str] = Field(
         None,
         description="When a job is within sig_time seconds of its end time, send it the signal sig_num.",
-        regex="[B:]<sig_num>[@<sig_time>]",
+        pattern="[B:]<sig_num>[@<sig_time>]",
     )
     sockets_per_node: Optional[int] = Field(
         None,

--- a/tests/util/test_rabbitmq.py
+++ b/tests/util/test_rabbitmq.py
@@ -190,6 +190,18 @@ def test_api_binding_declare(requests_mock, rmqapi, binding_spec):
     assert history.method == "POST"
     assert history.url.endswith("/api/bindings/zocalo/e/foo/q/bar")
     assert history.json() == {
+        "routing_key": "bar",
+    }
+
+def test_api_binding_declare_with_args(requests_mock, rmqapi, binding_spec):
+    binding_spec.arguments = {"test":"123"}
+    requests_mock.post("/api/bindings/zocalo/e/foo/q/bar")
+    rmqapi.binding_declare(binding=binding_spec)
+    assert requests_mock.call_count == 1
+    history = requests_mock.request_history[0]
+    assert history.method == "POST"
+    assert history.url.endswith("/api/bindings/zocalo/e/foo/q/bar")
+    assert history.json() == {
         "arguments": binding_spec.arguments,
         "routing_key": "bar",
     }
@@ -313,7 +325,6 @@ def test_api_exchange_declare(name, requests_mock, rmqapi):
         "type": "fanout",
         "auto_delete": True,
         "durable": True,
-        "arguments": {},
     }
 
 
@@ -511,8 +522,18 @@ def test_api_add_vhost(requests_mock, rmqapi, vhost_spec):
     history = requests_mock.request_history[0]
     assert history.method == "PUT"
     assert history.url.endswith(f"/api/vhosts/{vhost_spec.name}/")
+    assert history.json() == {}
+
+def test_api_add_vhost_with_tags(requests_mock, rmqapi, vhost_spec):
+    vhost_spec.tags = ["test123"]
+    requests_mock.put(f"/api/vhosts/{vhost_spec.name}/")
+    rmqapi.add_vhost(vhost=vhost_spec)
+    assert requests_mock.call_count == 1
+    history = requests_mock.request_history[0]
+    assert history.method == "PUT"
+    assert history.url.endswith(f"/api/vhosts/{vhost_spec.name}/")
     assert history.json() == {
-        "tags": [],
+        "tags": ["test123"],
     }
 
 


### PR DESCRIPTION
Makes a few small changes which hopefully represent much of what's needed to move to pydantic v2.

since then some autogenerated code in `util.slurm.models.py`  was added which is not pydantic 2 compatible, but `datamodel-codegen` claims to support pydantic v2 as well - @isikhar do you have an idea of whether updating this is as simple as regenerating it with different settings or if there is more that would need to be done?

