### PR TITLE
Allow rabbitmq configurator to run on default VHost

### DIFF
--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -464,7 +464,7 @@ def run():
                 logger.error(f"Error 404: VHost not found for url: {e.response.url}")
                 sys.exit(1)
         except Exception:
-            raise
+            raise e
         logger.error(e)
         sys.exit(1)
 


### PR DESCRIPTION
The default vhost is `/`, which caused a failure with existing logic because it tried to access URL e.g. `/api/exchanges///`. This is achieved by accessing `/api/exchanges/%2F/`.

Also, the actual error output when this happened was obscured by raising instead of re-raising. Fix this.