### PR TITLE
dlq_purge: Show what queues messages came from

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ Unreleased
 ----------
 - Minimum supported python is now 3.11.
 - Switch python packaging backend back to setuptools. (`#263 <https://github.com/DiamondLightSource/python-zocalo/pull/263>`_)
+- ``zocalo.dlq_purge``: Show which queues DLQ messages came from, and accept queue names with prefix. (`#264 <https://github.com/DiamondLightSource/python-zocalo/pull/264>`_)
 
 1.2.0 (2024-11-14)
 ------------------

--- a/src/zocalo/cli/dlq_purge.py
+++ b/src/zocalo/cli/dlq_purge.py
@@ -60,7 +60,7 @@ def run() -> None:
 
     args = parser.parse_args(["--stomp-prfx=DLQ"] + sys.argv[1:])
     if args.transport == "PikaTransport":
-        queues = ["dlq." + a for a in args.queues]
+        queues = ["dlq." + a.removeprefix("dlq.") for a in args.queues]
     else:
         queues = args.queues
     transport = workflows.transport.lookup(args.transport)()


### PR DESCRIPTION
Now shows which queues messages came from, instead of mixing together outputs in somewhat arbitrary order. New output:
```
Looking for DLQ messages in 38 queues...
Found 13 DLQ messages in dlq.ispyb_connector
    Message 1 (2025-06-16 13:27:41) exported:
        /dls/tmp/zocalo/DLQ/2025-06-16/msg-20250616-132741-000-1
    Message 2 (2025-06-16 13:27:41) exported:
        /dls/tmp/zocalo/DLQ/2025-06-16/msg-20250616-132741-000-2
    Message 3 (2025-06-16 13:27:41) exported:
        /dls/tmp/zocalo/DLQ/2025-06-16/msg-20250616-132741-000-3
    Message 4 (2025-06-16 13:27:41) exported:
        /dls/tmp/zocalo/DLQ/2025-06-16/msg-20250616-132741-000-4
Done.
```

Also, accepts `dlq.*` names in rabbitmq, stripping off the `dlq.` part if present.