### PR TITLE
Fix tests when running with workflows=3.7

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,12 +4,12 @@ History
 
 1.6.0 (Unreleased)
 -----------------
-- Fix error running tests with Workflows 3.7 installed (`#307 <https://github.com/DiamondLightSource/python-zocalo/pull/307>`_)
+- Fix error running tests with Workflows 3.7 installed. (`#308 <https://github.com/DiamondLightSource/python-zocalo/pull/308>`_)
 
 1.5.0 (2026-06-10)
 ------------------
-- Add docs for writing your own plugin (`#305 <https://github.com/DiamondLightSource/python-zocalo/pull/305>`_)
-- Update SLURM API to v0.0.44 (`#306 <https://github.com/DiamondLightSource/python-zocalo/pull/306>`_)
+- Add docs for writing your own plugin. (`#305 <https://github.com/DiamondLightSource/python-zocalo/pull/305>`_)
+- Update SLURM API to v0.0.44. (`#306 <https://github.com/DiamondLightSource/python-zocalo/pull/306>`_)
 
 1.4.0 (2026-03-13)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,9 +2,12 @@
 History
 =======
 
+1.6.0 (Unreleased)
+-----------------
+- Fix error running tests with Workflows 3.7 installed (`#307 <https://github.com/DiamondLightSource/python-zocalo/pull/307>`_)
+
 1.5.0 (2026-06-10)
 ------------------
-
 - Add docs for writing your own plugin (`#305 <https://github.com/DiamondLightSource/python-zocalo/pull/305>`_)
 - Update SLURM API to v0.0.44 (`#306 <https://github.com/DiamondLightSource/python-zocalo/pull/306>`_)
 

--- a/tests/service/test_dispatcher.py
+++ b/tests/service/test_dispatcher.py
@@ -17,6 +17,7 @@ def mock_zocalo_configuration(tmp_path):
     mock_zc.storage = {
         "zocalo.recipe_directory": tmp_path,
     }
+    mock_zc._opentelemetry = None
     return mock_zc
 
 


### PR DESCRIPTION
This constructed an always-truthy mock, which inadvertantly activated the OTEL pathways.