### PR TITLE
Add remaining missing type annotations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 -----------------
 - Fix error running tests with Workflows 3.7 installed. (`#308 <https://github.com/DiamondLightSource/python-zocalo/pull/308>`_)
 - Clean typing errors when linting with the pyright linter. (`#307 <https://github.com/DiamondLightSource/python-zocalo/pull/307>`_)
+- Provide a basic set of type annotations for all objects. (`#309 <https://github.com/DiamondLightSource/python-zocalo/pull/309>`_)
 
 1.5.0 (2026-06-10)
 ------------------

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -32,20 +32,20 @@ logger = logging.getLogger("zocalo.cli.configure_rabbitmq")
 
 
 class RabbitMQAPI(_RabbitMQAPI):
-    @functools.singledispatchmethod  # type: ignore
-    def create_component(self, component: BaseModel):
+    @functools.singledispatchmethod
+    def create_component(self, component: BaseModel) -> None:
         raise NotImplementedError(f"Component {component} not recognised")
 
-    @functools.singledispatchmethod  # type: ignore
-    def delete_component(self, component: BaseModel):
+    @functools.singledispatchmethod
+    def delete_component(self, component: BaseModel) -> None:
         raise NotImplementedError(f"Component {component} not recognised")
 
-    @create_component.register  # type: ignore
-    def _(self, binding: BindingSpec):
+    @create_component.register
+    def _(self, binding: BindingSpec) -> None:
         self.binding_declare(binding)
 
-    @delete_component.register  # type: ignore
-    def _(self, binding: BindingSpec):
+    @delete_component.register
+    def _(self, binding: BindingSpec) -> None:
         self.bindings_delete(
             vhost=binding.vhost,
             source=binding.source,
@@ -53,28 +53,28 @@ class RabbitMQAPI(_RabbitMQAPI):
             destination_type=binding.destination_type.value,
         )
 
-    @create_component.register  # type: ignore
-    def _(self, exchange: ExchangeSpec):
+    @create_component.register
+    def _(self, exchange: ExchangeSpec) -> None:
         self.exchange_declare(exchange)
 
-    @delete_component.register  # type: ignore
-    def _(self, exchange: ExchangeSpec, **kwargs):
+    @delete_component.register
+    def _(self, exchange: ExchangeSpec, **kwargs: Any) -> None:
         self.exchange_delete(vhost=exchange.vhost, name=exchange.name, **kwargs)
 
-    @create_component.register  # type: ignore
-    def _(self, vhost: VHostSpec):
+    @create_component.register
+    def _(self, vhost: VHostSpec) -> None:
         self.add_vhost(vhost)
 
-    @delete_component.register  # type: ignore
-    def _(self, vhost: VHostSpec):
+    @delete_component.register
+    def _(self, vhost: VHostSpec) -> None:
         self.delete_vhost(name=vhost.name)
 
-    @create_component.register  # type: ignore
-    def _(self, permissions: PermissionSpec):
+    @create_component.register
+    def _(self, permissions: PermissionSpec) -> None:
         self.set_permissions(permissions)
 
-    @delete_component.register  # type: ignore
-    def _(self, permissions: PermissionSpec):
+    @delete_component.register
+    def _(self, permissions: PermissionSpec) -> None:
         self.clear_permissions(vhost=permissions.vhost, user=permissions.user)
 
 

--- a/src/zocalo/cli/configure_rabbitmq.py
+++ b/src/zocalo/cli/configure_rabbitmq.py
@@ -79,24 +79,24 @@ class RabbitMQAPI(_RabbitMQAPI):
 
 
 @functools.singledispatch
-def _info_to_spec(incoming, infos: Sequence):
+def _info_to_spec(incoming: BaseModel, infos: Sequence[BaseModel]) -> list[BaseModel]:
     cls = type(incoming)
     return [cls(**i.model_dump()) for i in infos]
 
 
 @functools.singledispatch
-def _skip(comp) -> bool:
+def _skip(comp: BaseModel) -> bool:
     return False
 
 
-@_skip.register  # type: ignore
+@_skip.register
 def _(comp: ExchangeSpec) -> bool:
     if comp.name == "" or "amq." in comp.name:
         return True
     return False
 
 
-@_skip.register  # type: ignore
+@_skip.register
 def _(comp: BindingSpec) -> bool:
     if comp.source == "" or "amq." in comp.source:
         return True
@@ -105,7 +105,7 @@ def _(comp: BindingSpec) -> bool:
 
 def update_config(
     api: RabbitMQAPI, incoming: Sequence[BaseModel], current: Sequence[BaseModel]
-):
+) -> None:
     cls = type(incoming[0])
     current = _info_to_spec(incoming[0], current)
     for cc in current:
@@ -267,7 +267,7 @@ def get_exchange_specs_for_group(group: dict) -> list[ExchangeSpec]:
     ]
 
 
-def _configure_policies(api, policies: list[dict[str, Any]]):
+def _configure_policies(api: RabbitMQAPI, policies: list[dict[str, Any]]) -> None:
     existing_policies = {
         (policy.vhost, policy.name): policy for policy in api.policies()
     }
@@ -301,7 +301,7 @@ def _configure_policies(api, policies: list[dict[str, Any]]):
         api.clear_policy(vhost=policy_id[0], name=policy_id[1])
 
 
-def _configure_queues(api, queues: list[QueueSpec]):
+def _configure_queues(api: RabbitMQAPI, queues: list[QueueSpec]) -> None:
     existing_queues = {(q.vhost, q.name): q for q in api.queues()}
     known_queues: set[tuple[str, str]] = set()
 
@@ -336,7 +336,7 @@ def _configure_queues(api, queues: list[QueueSpec]):
         api.queue_delete(vhost=queue_id[0], name=queue_id[1])
 
 
-def _configure_users(api, rabbitmq_user_config_area: Path):
+def _configure_users(api: RabbitMQAPI, rabbitmq_user_config_area: Path) -> None:
     existing_users = {user.name: user for user in api.users()}
 
     planned_users: dict[str, Path] = {}
@@ -387,7 +387,7 @@ def _configure_users(api, rabbitmq_user_config_area: Path):
         api.user_delete(name=user)
 
 
-def run():
+def run() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     handler = logging.getLogger().handlers[0]
 

--- a/src/zocalo/cli/dlq_check.py
+++ b/src/zocalo/cli/dlq_check.py
@@ -34,7 +34,7 @@ def check_dlq(
         return {}
     assert result["status"] == 200, result
 
-    def extract_queue_name(namestring):
+    def extract_queue_name(namestring: str) -> str | None:
         namestringdict = {
             component.split("=")[0]: component.split("=", 1)[1]
             for component in namestring.split(",")

--- a/src/zocalo/cli/dlq_purge.py
+++ b/src/zocalo/cli/dlq_purge.py
@@ -72,7 +72,11 @@ def run() -> None:
     idlequeue: queue.Queue[Literal["start", "done"] | tuple[str, str]] = queue.Queue()
 
     def receive_dlq_message(
-        header: Mapping[str, Any], message: Any, *, queue_name: str, rabbitmq=False
+        header: Mapping[str, Any],
+        message: Any,
+        *,
+        queue_name: str,
+        rabbitmq: bool = False,
     ) -> None:
         idlequeue.put_nowait("start")
         if rabbitmq:

--- a/src/zocalo/cli/go.py
+++ b/src/zocalo/cli/go.py
@@ -13,6 +13,7 @@ import socket
 import sys
 import uuid
 from pprint import pprint
+from typing import Any, Literal
 
 import workflows.recipe
 import workflows.transport
@@ -22,7 +23,7 @@ import zocalo.configuration.argparse
 # Example: zocalo.go -r example-xia2 527189
 
 
-def run():
+def run() -> None:
     zc = zocalo.configuration.from_file()
     zc.activate()
 
@@ -119,12 +120,15 @@ def run():
     workflows.transport.add_command_line_options(parser, transport_argument=True)
     args = parser.parse_args()
 
+    dropfile_fallback: pathlib.Path | Literal[False]
     if zc.storage and zc.storage.get("zocalo.go.fallback_location"):
         dropfile_fallback = pathlib.Path(zc.storage["zocalo.go.fallback_location"])
     else:
         dropfile_fallback = False
 
-    def write_message_to_dropfile(message, headers):
+    def write_message_to_dropfile(
+        message: dict[str, Any], headers: dict[str, str]
+    ) -> None:
         message_serialized = (
             json.dumps({"headers": headers, "message": message}, indent=2) + "\n"
         )
@@ -136,7 +140,7 @@ def run():
         fallback.write_text(message_serialized)
         print("Message successfully stored in %s" % fallback)
 
-    def send_or_defer(message):
+    def send_or_defer(message: dict[str, Any]) -> None:
         headers = {
             "zocalo.go.user": getpass.getuser(),
             "zocalo.go.host": socket.gethostname(),

--- a/src/zocalo/cli/pickup.py
+++ b/src/zocalo/cli/pickup.py
@@ -5,13 +5,14 @@ import json
 import pathlib
 import sys
 import time
+from typing import Any
 
 import workflows.transport
 
 import zocalo.configuration
 
 
-def run():
+def run() -> None:
     zc = zocalo.configuration.from_file()
     zc.activate()
     dropdir = pathlib.Path(zc.storage["zocalo.go.fallback_location"])
@@ -68,7 +69,7 @@ def run():
     transport = workflows.transport.lookup(args.transport)()
     transport.connect()
 
-    file_info = {f: {} for f in files}
+    file_info: dict[pathlib.Path, dict[str, Any]] = {f: {} for f in files}
 
     for f, finfo in file_info.items():
         with f.open() as fh:

--- a/src/zocalo/cli/queue_drain.py
+++ b/src/zocalo/cli/queue_drain.py
@@ -10,7 +10,9 @@ import argparse
 import queue
 import sys
 import time
+from collections.abc import Mapping
 from datetime import datetime
+from typing import Any
 
 import workflows.recipe.wrapper
 import workflows.transport
@@ -18,7 +20,7 @@ import workflows.transport
 import zocalo.configuration
 
 
-def show_cluster_info(step):
+def show_cluster_info(step: dict[str, Any]) -> None:
     try:
         print("Beamline " + step["parameters"]["cluster_project"].upper())
     except Exception:
@@ -32,7 +34,7 @@ def show_cluster_info(step):
 show_additional_info = {"cluster.submission": show_cluster_info}
 
 
-def run(args=None):
+def run(argv: list[str] | None = None) -> None:
     # Load configuration
     zc = zocalo.configuration.from_file()
     zc.activate()
@@ -66,14 +68,14 @@ def run(args=None):
     )
     zc.add_command_line_options(parser)
     workflows.transport.add_command_line_options(parser, transport_argument=True)
-    args = parser.parse_args(args)
+    args = parser.parse_args(argv)
 
     transport = workflows.transport.lookup(args.transport)()
     transport.connect()
 
-    messages = queue.Queue()
+    messages: queue.Queue[tuple[Mapping[str, Any], Any]] = queue.Queue()
 
-    def receive_message(header, message):
+    def receive_message(header: Mapping[str, Any], message: Any) -> None:
         messages.put((header, message))
 
     print(f"Reading messages from {args.SOURCE}")
@@ -101,7 +103,7 @@ def run(args=None):
         }
     )
     drain_start = time.time()
-    idle_time = 0
+    idle_time = 0.0
     try:
         while True:
             try:
@@ -132,6 +134,7 @@ def run(args=None):
                     print(f"Target Queue: {target_queue}")
                 additional_info_function = show_additional_info.get(target_queue)
                 if additional_info_function:
+                    assert r.recipe_step
                     additional_info_function(r.recipe_step)
             except Exception:
                 pass

--- a/src/zocalo/cli/shutdown.py
+++ b/src/zocalo/cli/shutdown.py
@@ -16,7 +16,7 @@ import workflows.transport
 import zocalo.configuration
 
 
-def run(args=None):
+def run(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
 
     # Load configuration
@@ -43,7 +43,7 @@ def run(args=None):
     )
     zc.add_command_line_options(parser)
     workflows.transport.add_command_line_options(parser, transport_argument=True)
-    args = parser.parse_args(args)
+    args = parser.parse_args(argv)
 
     if not args.services and not len(args.HOSTS):
         print("Need to specify one or more services to shut down.")

--- a/src/zocalo/cli/wrap.py
+++ b/src/zocalo/cli/wrap.py
@@ -23,7 +23,7 @@ import zocalo.util
 import zocalo.wrapper
 
 
-def _enable_faulthandler():
+def _enable_faulthandler() -> None:
     """Display a traceback on crashing with non-Python errors, such as
     segmentation faults, and when the process is signalled with SIGUSR2
     (not available on Windows)"""
@@ -36,7 +36,7 @@ def _enable_faulthandler():
         pass
 
 
-def run():
+def run() -> None:
     zc = zocalo.configuration.from_file()
     zc.activate()
 

--- a/src/zocalo/configuration/__init__.py
+++ b/src/zocalo/configuration/__init__.py
@@ -99,7 +99,7 @@ class Configuration:
     def active_environments(self) -> tuple[str, ...]:
         return tuple(self._activated)
 
-    def _resolve(self, plugin_configuration: str):
+    def _resolve(self, plugin_configuration: str) -> None:
         try:
             configuration = self._plugin_configurations[
                 plugin_configuration
@@ -124,7 +124,7 @@ class Configuration:
             )
         self._plugin_configurations[plugin_configuration] = yaml_dict
 
-    def activate_environment(self, name: str):
+    def activate_environment(self, name: str) -> None:
         """Load all plugins for a given environment."""
         if name not in self._environments:
             raise ValueError(f"Environment '{name}' is not defined")
@@ -178,7 +178,7 @@ class Configuration:
             self.activate_environment(environment)
         return tuple(envs)
 
-    def add_command_line_options(self, parser):
+    def add_command_line_options(self, parser: typing.Any) -> None:
         """function to inject command line parameters"""
         if "add_argument" in dir(parser):
             parser.add_argument(
@@ -422,7 +422,7 @@ def _merge_configuration(
     return parsed
 
 
-def from_file(config_file=None) -> Configuration:
+def from_file(config_file: str | os.PathLike | None = None) -> Configuration:
     if not config_file:
         config_file = os.environ.get("ZOCALO_CONFIG")
     if not config_file:

--- a/src/zocalo/configuration/argparse.py
+++ b/src/zocalo/configuration/argparse.py
@@ -2,21 +2,25 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Iterable
+from typing import Any
 
 __all__ = ["get_specified_environments"]
 
 
 class _EnvParser(argparse.ArgumentParser):
-    def __init__(self, *args, add_help=False, **kwargs):
-        super().__init__(*args, add_help=add_help, **kwargs)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.setdefault("add_help", False)
+        super().__init__(*args, **kwargs)
 
-    def error(self, *args, **kwargs):  # type: ignore[IncompatibleMethodOverride]
+    def error(self, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
         # don't exit on error
         return None
 
 
 def get_specified_environments(
-    argv=None, *, arguments: Iterable[str] = ("-e", "--environment")
+    argv: list[str] | None = None,
+    *,
+    arguments: Iterable[str] = ("-e", "--environment"),
 ) -> list[str]:
     """Extract a list of all environments putatively specified on the command line.
     Returns an empty list if there are any parsing issues or there are no specified

--- a/src/zocalo/configuration/plugin_graylog.py
+++ b/src/zocalo/configuration/plugin_graylog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import socket
 import warnings
+from typing import Any
 
 import graypy.handler
 from marshmallow import fields, validate
@@ -17,7 +18,7 @@ class _PythonLevelToSyslogConverter:
     """
 
     @staticmethod
-    def get(level, _):
+    def get(level: int, _: object) -> int:
         if level < 20:
             return 7  # DEBUG
         elif level < 25:
@@ -45,7 +46,7 @@ class Graylog:
         port = fields.Int(required=True)
 
     @staticmethod
-    def activate(configuration):
+    def activate(configuration: dict[str, Any]) -> logging.Handler:
         warnings.warn(
             "The Graylog configuration plugin will soon be deprecated."
             " It will be replaced by the more powerful logging plugin.",

--- a/src/zocalo/configuration/plugin_jmx.py
+++ b/src/zocalo/configuration/plugin_jmx.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from marshmallow import fields
 
 from zocalo.configuration import PluginSchema
@@ -14,5 +16,5 @@ class JMX:
         password = fields.Str(required=True)
 
     @staticmethod
-    def activate(configuration):
+    def activate(configuration: dict[str, Any]) -> dict[str, Any]:
         return configuration

--- a/src/zocalo/configuration/plugin_logging.py
+++ b/src/zocalo/configuration/plugin_logging.py
@@ -104,7 +104,7 @@ def _monkeypatch_graypy() -> None:
 
     class PythonLevelToSyslogConverter:
         @staticmethod
-        def get(level, _):
+        def get(level: int, _: object) -> int:
             if level < 20:
                 return 7  # DEBUG
             elif level < 25:

--- a/src/zocalo/configuration/plugin_rabbitmqapi.py
+++ b/src/zocalo/configuration/plugin_rabbitmqapi.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from marshmallow import fields
 
 from zocalo.configuration import PluginSchema
@@ -13,6 +15,6 @@ class RabbitAPI:
         vhost = fields.Str()
 
     @staticmethod
-    def activate(configuration):
+    def activate(configuration: dict[str, Any]) -> dict[str, Any]:
         configuration.setdefault("vhost", "/")
         return configuration

--- a/src/zocalo/configuration/plugin_slurm.py
+++ b/src/zocalo/configuration/plugin_slurm.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from marshmallow import fields
 
 from zocalo.configuration import PluginSchema
@@ -13,5 +15,5 @@ class Slurm:
         api_version = fields.Str(required=True)
 
     @staticmethod
-    def activate(configuration):
+    def activate(configuration: dict[str, Any]) -> dict[str, Any]:
         return configuration

--- a/src/zocalo/configuration/plugin_smtp.py
+++ b/src/zocalo/configuration/plugin_smtp.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from marshmallow import fields
 
 from zocalo.configuration import PluginSchema
@@ -12,5 +14,5 @@ class SMTP:
         from_ = fields.Email(data_key="from")
 
     @staticmethod
-    def activate(configuration):
+    def activate(configuration: dict[str, Any]) -> dict[str, Any]:
         return configuration

--- a/src/zocalo/configuration/plugin_storage.py
+++ b/src/zocalo/configuration/plugin_storage.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from zocalo.configuration import Configuration
+
 
 class Storage:
     @staticmethod
-    def activate(configuration, config_object):
+    def activate(
+        configuration: dict[str, Any], config_object: Configuration
+    ) -> dict[str, Any]:
         storage = config_object.storage or {}
         storage.update(configuration)
         return storage

--- a/src/zocalo/service/__init__.py
+++ b/src/zocalo/service/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import sys
+from typing import Any
 
 import workflows.contrib.start_service
 import workflows.transport
@@ -10,7 +11,7 @@ import zocalo.configuration.argparse
 import zocalo.util
 
 
-def start_service():
+def start_service() -> None:
     ServiceStarter().run(
         program_name="zocalo.service",
         version=zocalo.__version__,
@@ -23,7 +24,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
 
     __frontendref = None
 
-    def setup_logging(self):
+    def setup_logging(self) -> None:
         """Initialize common logging framework. Everything is logged to central
         graylog server. Depending on setting messages of DEBUG or INFO and higher
         go to console."""
@@ -66,7 +67,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
                 "zocalo.default_transport"
             ]
 
-    def on_parser_preparation(self, parser):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def on_parser_preparation(self, parser: Any) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
         parser.add_option(
             "-v",
             "--verbose",
@@ -100,7 +101,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
         self._zc.add_command_line_options(parser)
         self.log.debug("Launching %r", sys.argv)
 
-    def on_parsing(self, options, args):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def on_parsing(self, options: Any, args: Any) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
         if options.verbose:
             self.console.setLevel(logging.DEBUG)
             if self._zc.logging:
@@ -113,14 +114,14 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
                 logging.getLogger("workflows").setLevel(logging.DEBUG)
         self.options = options
 
-    def before_frontend_construction(self, kwargs):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def before_frontend_construction(self, kwargs: dict[str, Any]) -> dict[str, Any]:  # pyright: ignore[reportIncompatibleMethodOverride]
         kwargs["verbose_service"] = True
         kwargs["environment"] = kwargs.get("environment", {})
         kwargs["environment"]["live"] = self.use_live_infrastructure
         kwargs["environment"]["config"] = self._zc
         return kwargs
 
-    def on_frontend_preparation(self, frontend):  # pyright: ignore[reportIncompatibleMethodOverride]
+    def on_frontend_preparation(self, frontend: Any) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
         if self.options.service_restart:
             frontend.restart_service = True
 
@@ -130,7 +131,7 @@ class ServiceStarter(workflows.contrib.start_service.ServiceStarter):
 
         original_status_function = frontend.get_status
 
-        def extend_status_wrapper():
+        def extend_status_wrapper() -> dict[str, Any]:
             status = original_status_function()
             status.update(extended_status)
             return status

--- a/src/zocalo/service/dispatcher.py
+++ b/src/zocalo/service/dispatcher.py
@@ -9,6 +9,7 @@ import time
 import timeit
 import uuid
 from importlib.metadata import entry_points
+from typing import Any, TextIO
 
 import workflows.recipe
 from opentelemetry import trace
@@ -34,7 +35,9 @@ class Dispatcher(CommonService):
     # Logger name
     _logger_name = "zocalo.service.dispatcher"
 
-    def filter_load_recipes_from_files(self, message, parameters):
+    def filter_load_recipes_from_files(
+        self, message: dict[str, Any], parameters: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Load named recipes from central location and merge them into the recipe object"""
         for recipefile in message.get("recipes", []):
             try:
@@ -57,7 +60,9 @@ class Dispatcher(CommonService):
             message["recipe"] = message["recipe"].merge(named_recipe)
         return message, parameters
 
-    def filter_load_custom_recipe(self, message, parameters):
+    def filter_load_custom_recipe(
+        self, message: dict[str, Any], parameters: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Load a custom recipe from a message and merge them into the recipe object"""
         if message.get("custom_recipe"):
             try:
@@ -81,13 +86,15 @@ class Dispatcher(CommonService):
             message["recipe"] = message["recipe"].merge(custom_recipe)
         return message, parameters
 
-    def filter_apply_parameters(self, message, parameters):
+    def filter_apply_parameters(
+        self, message: dict[str, Any], parameters: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Fill in any placeholders in the recipe of the form {name} using the
         parameters data structure"""
         message["recipe"].apply_parameters(parameters)
         return message, parameters
 
-    def initializing(self):
+    def initializing(self) -> None:
         """Subscribe to the processing_recipe queue. Received messages must be acknowledged."""
         self.log.info("Dispatcher starting")
         self.recipe_basepath = self._environment["config"].storage.get(
@@ -139,7 +146,14 @@ class Dispatcher(CommonService):
             allow_non_recipe_messages=True,
         )
 
-    def record_to_logbook(self, guid, header, original_message, message, recipewrap):
+    def record_to_logbook(
+        self,
+        guid: str,
+        header: dict[str, Any],
+        original_message: dict[str, Any],
+        message: dict[str, Any],
+        recipewrap: workflows.recipe.RecipeWrapper,
+    ) -> None:
         assert self._logbook is not None
         basepath = os.path.join(self._logbook, time.strftime("%Y-%m"))
         clean_guid = re.sub(r"[^a-z0-9A-Z\-]+", "", guid, re.UNICODE)
@@ -153,8 +167,8 @@ class Dispatcher(CommonService):
         except OSError:
             pass  # Ignore if exists
 
-        def neat_json_to_file(obj, fh, **kwargs):
-            def _fix(item):
+        def neat_json_to_file(obj: Any, fh: TextIO, **kwargs: Any) -> None:
+            def _fix(item: Any) -> Any:
                 if isinstance(item, list):
                     return [_fix(i) for i in item]
                 if isinstance(item, dict):
@@ -191,7 +205,12 @@ class Dispatcher(CommonService):
         except Exception:
             self.log.warning("Could not write message to logbook", exc_info=True)
 
-    def process(self, rw, header, message):
+    def process(
+        self,
+        rw: workflows.recipe.RecipeWrapper | None,
+        header: dict,
+        message: Any,
+    ) -> None:
         """Process an incoming processing request."""
         # Time execution
         start_time = timeit.default_timer()

--- a/src/zocalo/service/jsonlines.py
+++ b/src/zocalo/service/jsonlines.py
@@ -19,7 +19,7 @@ class JSONLines(CommonService):
 
     _data: dict[Path, list[tuple[dict, dict]]]
 
-    def initializing(self):
+    def initializing(self) -> None:
         self._register_idle(1, self.process_messages)
         workflows.recipe.wrap_subscribe(
             self.transport,
@@ -35,7 +35,7 @@ class JSONLines(CommonService):
 
     def receive_msg(
         self, rw: workflows.recipe.RecipeWrapper, header: dict, message: dict
-    ):
+    ) -> None:
         assert rw.recipe_step
         output_filename = rw.recipe_step["parameters"]["output_filename"]
         if not output_filename:
@@ -64,7 +64,7 @@ class JSONLines(CommonService):
             self.log.info("Triggering process messages")
             self.process_messages()
 
-    def process_messages(self):
+    def process_messages(self) -> None:
         with self._lock:
             for output_filename in list(self._data):
                 grouped_data = self._data[output_filename]

--- a/src/zocalo/service/mailer.py
+++ b/src/zocalo/service/mailer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import email.message
 import pprint
 import smtplib
+from typing import Any
 
 import workflows.recipe
 from workflows.services.common_service import CommonService
@@ -14,7 +15,7 @@ class _SafeDict(dict):
     """A dictionary that returns undefined keys as {keyname}.
     This can be used to selectively replace variables in datastructures."""
 
-    def __missing__(self, key):
+    def __missing__(self, key: str) -> str:
         return "{" + key + "}"
 
 
@@ -27,7 +28,7 @@ class Mailer(CommonService):
     # Logger name
     _logger_name = "zocalo.services.mailer"
 
-    def initializing(self):
+    def initializing(self) -> None:
         """Subscribe to the Mail notification queue.
         Received messages must be acknowledged."""
         self.log.debug("Mail notifications starting")
@@ -49,7 +50,7 @@ class Mailer(CommonService):
         )
 
     @staticmethod
-    def listify(recipients):
+    def listify(recipients: Any) -> list:
         if isinstance(recipients, list):
             return recipients
         elif isinstance(recipients, tuple):
@@ -57,12 +58,15 @@ class Mailer(CommonService):
         else:
             return [recipients]
 
-    def receive_msg(self, rw, header, message):
+    def receive_msg(
+        self, rw: workflows.recipe.RecipeWrapper | None, header: dict, message: Any
+    ) -> None:
         """Do some mail notification."""
 
         self.log.info(f"{message=}")
 
         if rw:
+            assert rw.recipe_step
             parameters = rw.recipe_step["parameters"]
             content = None
         else:

--- a/src/zocalo/service/schlockmeister.py
+++ b/src/zocalo/service/schlockmeister.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import collections
 import uuid
+from collections.abc import Mapping
 from typing import Any
 
 from workflows.services.common_service import CommonService
@@ -40,7 +41,7 @@ class Schlockmeister(CommonService):
     known_consumers: dict[tuple[Any, Any, Any], str] = {}
     known_instances: set[str] = set()
 
-    def initializing(self):
+    def initializing(self) -> None:
         """
         Subscribe to all queues. Received messages must be acknowledged.
         Only receive messages that have been delivered 5 times in the past.
@@ -71,17 +72,17 @@ class Schlockmeister(CommonService):
         self._register_idle(90, self._namespace_determination_failure)
 
     @staticmethod
-    def ignore(header, message):
+    def ignore(header: Mapping[str, Any], message: Any) -> None:
         """Ignore any messages on this subscription."""
 
-    def _namespace_determination_failure(self):
+    def _namespace_determination_failure(self) -> None:
         """Report namespace determination failure."""
         self.log.error(
             "Could not determine namespace within allocated time. Shutting down."
         )
         self._shutdown()
 
-    def watch_global(self, header, message):
+    def watch_global(self, header: Mapping[str, Any], message: Any) -> None:
         """
         Received information on one existing queue subscription.
         Try to identify the relevant transport namespace.
@@ -108,7 +109,7 @@ class Schlockmeister(CommonService):
                 ignore_namespace=True,
             )
 
-    def watch_local(self, header, message):
+    def watch_local(self, header: Mapping[str, Any], message: Any) -> None:
         """Keep track of queue consumers to identify active queues and topics."""
         if not isinstance(message, dict):
             return
@@ -173,7 +174,7 @@ class Schlockmeister(CommonService):
             self.log.warning("Received unknown message type\n%s", str(message))
         self.update_subscriptions()
 
-    def update_subscriptions(self):
+    def update_subscriptions(self) -> None:
         """Subscribe to any new queues with real subscribers."""
         for destination in self.known_queues:
             if self.known_queues[destination].get("subscription"):
@@ -194,7 +195,7 @@ class Schlockmeister(CommonService):
                     )
                 )
 
-    def garbage_collect(self):
+    def garbage_collect(self) -> None:
         """
         Delayed unsubscribe from lists that are without other subscribers.
         Clean up list of known queues.
@@ -224,7 +225,7 @@ class Schlockmeister(CommonService):
                     len(self.known_instances) - 1,
                 )
 
-    def quarantine(self, header, message):
+    def quarantine(self, header: Mapping[str, Any], message: Any) -> None:
         """Quarantine this message."""
 
         self.log.warning(

--- a/src/zocalo/util/jmxstats.py
+++ b/src/zocalo/util/jmxstats.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import base64
 import json
 import urllib.request
+from collections.abc import Callable
+from typing import Any
 
 import zocalo.configuration
 
@@ -22,20 +24,20 @@ import zocalo.configuration
 class JMXAPIPath:
     """A recursing helper object that encodes a JMX bean path."""
 
-    def __init__(self, path, callback):
+    def __init__(self, path: str, callback: Callable[..., Any]) -> None:
         self.path = path
         self.callback = callback
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.path
 
-    def __getattribute__(self, attribute):
+    def __getattribute__(self, attribute: str) -> Any:
         try:
             return object.__getattribute__(self, attribute)
         except AttributeError:
             return JMXAPIPath(self.path + "." + attribute, self.callback)
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.callback(self.path, *args, **kwargs)
 
 
@@ -60,20 +62,22 @@ class JMXAPI:
             ).decode()
         )
 
-    def __getattribute__(self, attribute):
+    def __getattribute__(self, attribute: str) -> Any:
         try:
             return object.__getattribute__(self, attribute)
         except AttributeError:
             return JMXAPIPath(attribute, self._call)
 
-    def _call(self, path, attribute=None, *args, **kwargs):
+    def _call(
+        self, path: str, attribute: str | None = None, *args: Any, **kwargs: str
+    ) -> Any:
         params = ",".join(key + "=" + value for key, value in kwargs.items())
         url = path + ":" + params
         if attribute:
             url = url + "/" + attribute
         return self._get(url)
 
-    def _get(self, url):
+    def _get(self, url: str) -> Any:
         complete_url = self.url + url
         req = urllib.request.Request(
             complete_url, headers={"Accept": "application/json"}

--- a/src/zocalo/util/rabbitmq.py
+++ b/src/zocalo/util/rabbitmq.py
@@ -10,7 +10,7 @@ import secrets
 import urllib
 import urllib.parse
 import urllib.request
-from typing import Any, overload
+from typing import Any, Self, overload
 
 import requests
 from pydantic import BaseModel, ConfigDict, Field
@@ -653,7 +653,7 @@ class RabbitMQAPI:
         self._session.auth = (user, password)
 
     @classmethod
-    def from_zocalo_configuration(cls, zc: zocalo.configuration.Configuration):
+    def from_zocalo_configuration(cls, zc: zocalo.configuration.Configuration) -> Self:
         instance = None
         base_url = zc.rabbitmqapi["base_url"]
         for url in base_url.split(","):
@@ -758,7 +758,7 @@ class RabbitMQAPI:
             endpoint = f"{endpoint}/e/{source}/{destination_type}/{destination}"
         dest_map = {"queue": "q", "exchange": "e"}
 
-        def conv(key, value):
+        def conv(key: str, value: Any) -> Any:
             return dest_map[value] if key == "destination_type" else value
 
         return [
@@ -766,7 +766,7 @@ class RabbitMQAPI:
             for r in self.get(endpoint).json()
         ]
 
-    def binding_declare(self, binding: BindingSpec):
+    def binding_declare(self, binding: BindingSpec) -> None:
         endpoint = f"bindings/{binding.vhost}/e/{binding.source}/{binding.destination_type.value}/{binding.destination}"
         response = self.post(
             endpoint,
@@ -784,7 +784,7 @@ class RabbitMQAPI:
         destination: str,
         destination_type: str,
         properties_key: str | None = None,
-    ):
+    ) -> None:
         # If properties_key is not specified then all bindings between the specified
         # source and destination are deleted
         endpoint = (
@@ -793,7 +793,7 @@ class RabbitMQAPI:
         if properties_key is None:
             dest_map = {"queue": "q", "exchange": "e"}
 
-            def conv(key, value):
+            def conv(key: str, value: Any) -> Any:
                 return dest_map[value] if key == "destination_type" else value
 
             props = [
@@ -852,7 +852,7 @@ class RabbitMQAPI:
         response = self.get(endpoint)
         return [ExchangeInfo(**qi) for qi in response.json()]
 
-    def exchange_declare(self, exchange: ExchangeSpec):
+    def exchange_declare(self, exchange: ExchangeSpec) -> None:
         endpoint = f"exchanges/{exchange.vhost}/{exchange.name}/"
         response = self.put(
             endpoint,
@@ -860,7 +860,7 @@ class RabbitMQAPI:
         )
         response.raise_for_status()
 
-    def exchange_delete(self, vhost: str, name: str, if_unused: bool = False):
+    def exchange_delete(self, vhost: str, name: str, if_unused: bool = False) -> None:
         endpoint = f"exchanges/{_quote(vhost)}/{name}"
         response = self.delete(endpoint, params={"if-unused": if_unused})
         response.raise_for_status()
@@ -877,7 +877,7 @@ class RabbitMQAPI:
         response = self.get(endpoint)
         return PolicySpec(**response.json())
 
-    def set_policy(self, policy: PolicySpec):
+    def set_policy(self, policy: PolicySpec) -> None:
         endpoint = f"policies/{policy.vhost}/{policy.name}/"
         response = self.put(
             endpoint,
@@ -887,7 +887,7 @@ class RabbitMQAPI:
         )
         response.raise_for_status()
 
-    def clear_policy(self, vhost: str, name: str):
+    def clear_policy(self, vhost: str, name: str) -> None:
         endpoint = f"policies/{_quote(vhost)}/{name}/"
         response = self.delete(endpoint)
         response.raise_for_status()
@@ -915,7 +915,7 @@ class RabbitMQAPI:
         response = self.get(endpoint)
         return [QueueInfo(**qi) for qi in response.json()]
 
-    def queue_declare(self, queue: QueueSpec):
+    def queue_declare(self, queue: QueueSpec) -> None:
         endpoint = f"queues/{queue.vhost}/{queue.name}"
         response = self.put(
             endpoint,
@@ -925,7 +925,7 @@ class RabbitMQAPI:
 
     def queue_delete(
         self, vhost: str, name: str, if_unused: bool = False, if_empty: bool = False
-    ):
+    ) -> None:
         logger.debug(f"Deleting queue {_quote(vhost)}/{name}")
         endpoint = f"queues/{_quote(vhost)}/{name}"
         response = self.delete(
@@ -966,7 +966,7 @@ class RabbitMQAPI:
         response = self.get(endpoint)
         return [PermissionSpec(**ps) for ps in response.json()]
 
-    def set_permissions(self, permission: PermissionSpec):
+    def set_permissions(self, permission: PermissionSpec) -> None:
         endpoint = f"permissions/{permission.vhost}/{permission.user}/"
         submission = permission.model_dump(
             exclude_defaults=True, exclude={"vhost", "user"}
@@ -974,19 +974,19 @@ class RabbitMQAPI:
         response = self.put(endpoint, json=submission)
         response.raise_for_status()
 
-    def clear_permissions(self, vhost: str, user: str):
+    def clear_permissions(self, vhost: str, user: str) -> None:
         endpoint = f"permissions/{_quote(vhost)}/{user}/"
         response = self.delete(endpoint)
         response.raise_for_status()
 
-    def user_put(self, user: UserSpec):
+    def user_put(self, user: UserSpec) -> None:
         endpoint = f"users/{user.name}/"
         submission = user.model_dump(exclude_defaults=True, exclude={"name"})
         submission["tags"] = ",".join(submission["tags"])
         response = self.put(endpoint, json=submission)
         response.raise_for_status()
 
-    def user_delete(self, name: str):
+    def user_delete(self, name: str) -> None:
         endpoint = f"users/{name}/"
         response = self.delete(endpoint)
         response.raise_for_status()
@@ -1001,7 +1001,7 @@ class RabbitMQAPI:
         response = self.get(endpoint).json()
         return VHostSpec(**response)
 
-    def add_vhost(self, vhost: VHostSpec):
+    def add_vhost(self, vhost: VHostSpec) -> None:
         endpoint = f"vhosts/{vhost.name}/"
         response = self.put(
             endpoint,
@@ -1009,7 +1009,7 @@ class RabbitMQAPI:
         )
         response.raise_for_status()
 
-    def delete_vhost(self, name: str):
+    def delete_vhost(self, name: str) -> None:
         endpoint = f"vhosts/{name}/"
         response = self.delete(endpoint)
         response.raise_for_status()

--- a/src/zocalo/util/slurm/__init__.py
+++ b/src/zocalo/util/slurm/__init__.py
@@ -5,7 +5,7 @@ import binascii
 import json
 import os
 import pathlib
-from typing import Any
+from typing import Any, Self
 
 import requests
 
@@ -78,7 +78,9 @@ class SlurmRestApi:
             self.session.headers["X-SLURM-USER-TOKEN"] = self.user_token
 
     @classmethod
-    def from_zocalo_configuration(cls, zc: Configuration, cluster: str = "slurm"):
+    def from_zocalo_configuration(
+        cls, zc: Configuration, cluster: str = "slurm"
+    ) -> Self:
         cluster_config = getattr(zc, cluster)
         return cls(
             url=cluster_config["url"],

--- a/src/zocalo/wrapper.py
+++ b/src/zocalo/wrapper.py
@@ -3,60 +3,67 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
-from typing import Any, Mapping, NotRequired, TypedDict, cast
+from typing import TYPE_CHECKING, Any, Mapping, NotRequired, TypedDict, cast
 
 import workflows.services.common_service
 import workflows.util
 
 import zocalo
 
+if TYPE_CHECKING:
+    import workflows.recipe.wrapper
+
+    import zocalo.configuration
+
 
 class BaseWrapper:
     _logger_name = "zocalo.wrapper"  # The logger can be accessed via self.log
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._environment = kwargs.get("environment", {})
-        self.__log_extra = {}
+        self.__log_extra: dict[str, Any] = {}
         logger = logging.getLogger(self._logger_name)
         self.log = logging.LoggerAdapter(logger, extra=self.__log_extra)
 
-    def set_recipe_wrapper(self, recwrap):
+    def set_recipe_wrapper(
+        self, recwrap: workflows.recipe.wrapper.RecipeWrapper
+    ) -> None:
         self.recwrap = recwrap
         self.__log_extra["recipe_ID"] = recwrap.environment["ID"]
 
-    def prepare(self, payload=""):
+    def prepare(self, payload: Any = "") -> None:
         if getattr(self, "recwrap", None):
             self.recwrap.send_to("starting", payload)
 
-    def update(self, payload=""):
+    def update(self, payload: Any = "") -> None:
         if getattr(self, "recwrap", None):
             self.recwrap.send_to("updates", payload)
 
-    def done(self, payload=""):
+    def done(self, payload: Any = "") -> None:
         if getattr(self, "recwrap", None):
             self.recwrap.send_to("completed", payload)
 
-    def success(self, payload=""):
+    def success(self, payload: Any = "") -> None:
         if getattr(self, "recwrap", None):
             self.recwrap.send_to("success", payload)
 
-    def failure(self, payload=""):
+    def failure(self, payload: Any = "") -> None:
         if getattr(self, "recwrap", None):
             self.recwrap.send_to("failure", str(payload))
 
-    def run(self):
+    def run(self) -> bool:
         raise NotImplementedError()
 
-    def record_result_individual_file(self, payload=""):
+    def record_result_individual_file(self, payload: Any = "") -> None:
         if getattr(self, "recwrap", None):
             self.recwrap.send_to("result-individual-file", payload)
 
-    def record_result_all_files(self, payload=""):
+    def record_result_all_files(self, payload: Any = "") -> None:
         if getattr(self, "recwrap", None):
             self.recwrap.send_to("result-all-files", payload)
 
     @property
-    def config(self):
+    def config(self) -> zocalo.configuration.Configuration | None:
         return self._environment.get("config")
 
 
@@ -65,7 +72,7 @@ class DummyWrapper(BaseWrapper):
 
     status_thread: StatusNotifications
 
-    def run(self):
+    def run(self) -> bool:
         self.log.info("This is a dummy wrapper that simply waits for twenty seconds.")
         import time
 


### PR DESCRIPTION
This puts a basic set of annotations on all of the objects in zocalo that were missing annotations. In many cases this is just generic Any, rather than a deep study of what the types might be constrained to.

This makes pass:
```
% uv run ruff check --select ANN --ignore=ANN204,ANN401 src/zocalo --output-format=concise
```