### PR TITLE
Fix pydantic error In SLURM API model as gres_detail field can be an empty list

### DIFF
--- a/src/zocalo/util/slurm/models.py
+++ b/src/zocalo/util/slurm/models.py
@@ -738,8 +738,8 @@ class ProcessExitCodeVerbose(BaseModel):
     signal: Signal | None = None
 
 
-class JobInfoGresDetail(RootModel[List[str]]):
-    root: List[str]
+class JobInfoGresDetail(RootModel[List[str | None]]):
+    root: List[str | None]
 
 
 class SelectTypeEnum(StrEnum):


### PR DESCRIPTION
Apparently SLURM API v0.0.44 allows `gres_detail` field to be an empty string that results in current model implementation raising a pydantic error.
```pydantic_core._pydantic_core.ValidationError: 2 validation errors for OpenapiJobInfoResp
jobs.130.gres_detail.0
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.13/v/string_type
```
This patch fixes this issue enabling `JobInfoGresDetail` type object to be an empty list.